### PR TITLE
fix: CVSS v3 environmental score calculation bug

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -466,15 +466,47 @@ impl CvssV3 {
         let i = self.integrity_impact.as_ref()?;
         let a = self.availability_impact.as_ref()?;
 
-        // Modified metrics default to base metrics if not defined
-        let mav = self.modified_attack_vector.as_ref().unwrap_or(av);
-        let mac = self.modified_attack_complexity.as_ref().unwrap_or(ac);
-        let mpr = self.modified_privileges_required.as_ref().unwrap_or(pr);
-        let mui = self.modified_user_interaction.as_ref().unwrap_or(ui);
-        let ms = self.modified_scope.as_ref().unwrap_or(scope);
-        let mc = self.modified_confidentiality_impact.as_ref().unwrap_or(c);
-        let mi = self.modified_integrity_impact.as_ref().unwrap_or(i);
-        let ma = self.modified_availability_impact.as_ref().unwrap_or(a);
+        // Modified metrics: if not present or set to NotDefined (X), fall back to base metric
+        let mav = self
+            .modified_attack_vector
+            .as_ref()
+            .filter(|v| !matches!(v, AttackVector::NotDefined))
+            .unwrap_or(av);
+        let mac = self
+            .modified_attack_complexity
+            .as_ref()
+            .filter(|v| !matches!(v, AttackComplexity::NotDefined))
+            .unwrap_or(ac);
+        let mpr = self
+            .modified_privileges_required
+            .as_ref()
+            .filter(|v| !matches!(v, PrivilegesRequired::NotDefined))
+            .unwrap_or(pr);
+        let mui = self
+            .modified_user_interaction
+            .as_ref()
+            .filter(|v| !matches!(v, UserInteraction::NotDefined))
+            .unwrap_or(ui);
+        let ms = self
+            .modified_scope
+            .as_ref()
+            .filter(|v| !matches!(v, Scope::NotDefined))
+            .unwrap_or(scope);
+        let mc = self
+            .modified_confidentiality_impact
+            .as_ref()
+            .filter(|v| !matches!(v, Impact::NotDefined))
+            .unwrap_or(c);
+        let mi = self
+            .modified_integrity_impact
+            .as_ref()
+            .filter(|v| !matches!(v, Impact::NotDefined))
+            .unwrap_or(i);
+        let ma = self
+            .modified_availability_impact
+            .as_ref()
+            .filter(|v| !matches!(v, Impact::NotDefined))
+            .unwrap_or(a);
 
         // Security requirements default to 1.0 (Medium/NotDefined)
         let cr = self

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -77,3 +77,30 @@ fn test_v3_zero_impact_score() {
         .expect("Failed to calculate score");
     assert_eq!(calculated_score, 0.0);
 }
+
+#[test]
+fn test_v3_cve_with_explicit_not_defined() {
+    // This vector is based on an issue brought up here: https://github.com/scm-rs/cvss-rs/issues/9
+    // This tests that explicit `NotDefined` / `X` values in the modified metrics used in the
+    // environmental score calculation are handled correctly / like implicit
+    // "NotDefined" values caused by absence in the vector string.
+    let vector =
+        "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/MAV:A/MAC:L/MPR:N/MUI:X/MS:U/CR:L/IR:H/AR:X";
+    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
+
+    let base_score = cvss
+        .calculated_base_score()
+        .expect("Failed to calculate base score");
+
+    let temporal_score = cvss
+        .calculated_temporal_score()
+        .expect("Failed to calculate temporal score");
+
+    let environmental_score = cvss
+        .calculated_environmental_score()
+        .expect("Failed to calculate environmental score");
+
+    assert_eq!(base_score, 7.8);
+    assert_eq!(temporal_score, 7.8);
+    assert_eq!(environmental_score, 8.0);
+}


### PR DESCRIPTION
This PR related to #9 and contains:

* Bug fix in v3 environmental score calculation
* Test case to cover that bug

The wrong environmental score calculation was caused by a wrong handling of explicit `NotDefined` / `X` values in the previous implementation. 

In the modified metrics used in the environmental score calculation, a `NotDefined` should result in the respective base metric being used (i.e. `MUI:X` should use the value of `UI`). This worked if the metric was implicitly `NotDefined` through absence in the vector string. 

If the metric was explicitly `NotDefined` through an `X` in the vector string, the `unwrap()` was called on `Some(SomeModifiedMetric::NotDefined)`, which returned the worst-case value of the base metric, instead of using the actual value of the base metric.

We should consider a cleaner implementation of this default mechanism for the modified metrics, exp. via a trait. But for now, this should fix the bug at hand.