### PR TITLE
feat: add vectors from v3.0/3.1 examples for as v2.0 and v3 tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["parser-implementations", "data-structures", "security"]
 readme = "README.md"
 
 [dependencies]
+rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }

--- a/tests/score_calculation_tests/v2_tests.rs
+++ b/tests/score_calculation_tests/v2_tests.rs
@@ -1,157 +1,178 @@
 use cvss_rs::v2_0::CvssV2;
 use std::str::FromStr;
 
+/// Helper function to parse a CVSS v2.0 vector and verify base, temporal, and environmental scores
+///
+/// This function parses the provided CVSS v2.0 vector string and checks for each of the expected scores
+/// provided (base, temporal, environmental) if the calculated score matches the expected score.
+///
+/// Arguments:
+/// - `vector`: The CVSS v2.0 vector string to parse and evaluate
+/// - `expected_base`: The expected base score
+/// - `expected_temporal`: Optional expected temporal score
+/// - `expected_environmental`: Optional expected environmental score
+fn assert_v2_scores(
+    vector: &str,
+    expected_base: f64,
+    expected_temporal: Option<f64>,
+    expected_environmental: Option<f64>,
+) {
+    let cvss = CvssV2::from_str(vector)
+        .expect(&format!("Failed to parse CVSS v2 vector: {}", vector));
+
+    let calculated_base = cvss
+        .calculated_base_score()
+        .expect("Failed to calculate base score");
+    assert_eq!(
+        calculated_base, expected_base,
+        "Base score mismatch for vector: {}. Expected: {}, Calculated: {}",
+        vector, expected_base, calculated_base
+    );
+
+    if let Some(expected_temporal) = expected_temporal {
+        let calculated_temporal = cvss
+            .calculated_temporal_score()
+            .expect("Failed to calculate temporal score");
+        assert_eq!(
+            calculated_temporal, expected_temporal,
+            "Temporal score mismatch for vector: {}. Expected: {}, Calculated: {}",
+            vector, expected_temporal, calculated_temporal
+        );
+    }
+
+    if let Some(expected_environmental) = expected_environmental {
+        let calculated_environmental = cvss
+            .calculated_environmental_score()
+            .expect("Failed to calculate environmental score");
+        assert_eq!(
+            calculated_environmental, expected_environmental,
+            "Environmental score mismatch for vector: {}. Expected: {}, Calculated: {}",
+            vector, expected_environmental, calculated_environmental
+        );
+    }
+}
+
+/// Helper function to parse a CVSS v2.0 vector and verify only the base score
+fn assert_v2_base_score(vector: &str, expected_base: f64) {
+    assert_v2_scores(vector, expected_base, None, None);
+}
+
 #[test]
-fn test_v2_score_calculation() {
-    // AV:N/AC:L/Au:N/C:C/I:C/A:C
+fn test_v2_base_score_with_missing_temporal_and_environmental_metrics() {
     // This is a high severity vulnerability
     let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+    // With all temporal and environmental metrics missing, the metrics should default to NotDefined,
+    // so the temporal and environmental scores should be the same as the base score
+    assert_v2_scores(vector, 10.0, Some(10.0), Some(10.0));
+}
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    assert_eq!(calculated_score, 10.0);
+#[test]
+fn test_v2_base_score_with_not_defined_temporal_and_environmental_metrics() {
+    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:ND/RL:ND/RC:ND/CDP:ND/TD:ND/CR:ND/IR:ND/AR:ND";
+    // With all temporal and environmental metrics set to NotDefined,
+    // the temporal and environmental scores should be the same as the base score
+    assert_v2_scores(vector, 10.0, Some(10.0), Some(10.0));
 }
 
 #[test]
 fn test_v2_partial_impact_calculation() {
-    // AV:N/AC:L/Au:N/C:P/I:P/A:P
     let vector = "AV:N/AC:L/Au:N/C:P/I:P/A:P";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
-
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
     // Impact = 10.41 * (1 - (1-0.275)^3) = 6.443...
     // Exploitability = 20 * 1.0 * 0.71 * 0.704 = 10.0
     // Score = ((0.6*6.443) + (0.4*10.0) - 1.5) * 1.176 = 7.459... -> round to 7.5
-    assert_eq!(calculated_score, 7.5);
+    assert_v2_base_score(vector, 7.5);
 }
 
 #[test]
 fn test_v2_zero_impact_score() {
-    // AV:N/AC:L/Au:N/C:N/I:N/A:N
     let vector = "AV:N/AC:L/Au:N/C:N/I:N/A:N";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
-
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
     // Impact = 10.41 * (1 - (1-0)^3) = 0.0
     // Exploitability = 20 * 1.0 * 0.71 * 0.704 = 10.0
     // Score = ((0.6*0.0) + (0.4*10.0) - 1.5) * 0 = 0 (since impact is 0, f_impact is 0, so score should be 0)
-    assert_eq!(calculated_score, 0.0);
+    assert_v2_base_score(vector, 0.0);
 }
 
+/// These are real CVEs with the metrics taken from the official first.org CVSS examples.
 #[test]
-fn test_v2_undefined_temporal_and_environmental_metrics() {
-    // AV:N/AC:L/Au:N/C:C/I:C/A:C/E:ND/RL:ND/RC:ND/CDP:ND/TD:ND/CR:ND/IR:ND/AR:ND
-    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:ND/RL:ND/RC:ND/CDP:ND/TD:ND/CR:ND/IR:ND/AR:ND";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+fn test_real_cves() {
+    // [first.org CVE-2002-0392](https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392)
+    assert_v2_scores(
+        "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H",
+        7.8,
+        Some(6.4),
+        Some(9.2),
+    );
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    let calculated_temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
-    let calculated_environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // [first.org CVE-2003-0062](https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062)
+    assert_v2_scores(
+        "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M",
+        6.2,
+        Some(4.9),
+        Some(7.5),
+    );
 
-    // With all temporal and environmental metrics set to NotDefined,
-    // the temporal and environmental scores should be the same as the base score
-    assert_eq!(calculated_score, 10.0);
-    assert_eq!(calculated_temporal_score, 10.0);
-    assert_eq!(calculated_environmental_score, 10.0);
-}
+    // [first.org CVE-2003-0818](https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818)
+    assert_v2_scores(
+        "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L",
+        10.0,
+        Some(8.3),
+        Some(9.0),
+    );
 
-#[test]
-fn test_v2_missing_temporal_and_environmental_metrics() {
-    // AV:N/AC:L/Au:N/C:C/I:C/A:C
-    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+    // [first.org CVE-2013-1937](https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937)
+    assert_v2_base_score("AV:N/AC:L/Au:S/C:P/I:P/A:N", 5.5);
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    let calculated_temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
-    let calculated_environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // [first.org CVE-2014-3566](https://www.first.org/cvss/v3.0/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566)
+    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:N/A:N", 4.3);
 
-    // With all temporal and environmental metrics missing, the metrics should default to NotDefined,
-    // so the temporal and environmental scores should be the same as the base score
-    assert_eq!(calculated_score, 10.0);
-    assert_eq!(calculated_temporal_score, 10.0);
-    assert_eq!(calculated_environmental_score, 10.0);
-}
+    // [first.org CVE-2012-1516](https://www.first.org/cvss/v3.0/examples#VMware-Guest-to-Host-Escape-Vulnerability-CVE-2012-1516)
+    assert_v2_base_score("AV:N/AC:L/Au:S/C:C/I:C/A:C", 9.0);
 
-#[test]
-fn test_v2_real_cve_2002_0392() {
-    // This is a real CVE with the metrics taken from the official first.org CVSS Scoring Guide examples:
-    // https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392
-    let vector = "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+    // [first.org CVE-2009-0783](https://www.first.org/cvss/v3.0/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783)
+    assert_v2_base_score("AV:L/AC:L/Au:N/C:P/I:P/A:P", 4.6);
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    let calculated_temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
-    let calculated_environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // [first.org CVE-2012-0384](https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384)
+    assert_v2_base_score("AV:N/AC:M/Au:S/C:C/I:C/A:C", 8.5);
 
-    assert_eq!(calculated_score, 7.8);
-    assert_eq!(calculated_temporal_score, 6.4);
-    assert_eq!(calculated_environmental_score, 9.2);
-}
+    // [first.org CVE-2015-1098](https://www.first.org/cvss/v3.0/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098)
+    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:P", 6.8);
 
-#[test]
-fn test_v2_real_cve_2003_0062() {
-    // This is a real CVE with the metrics taken from the official first.org CVSS Scoring Guide examples:
-    // https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062
-    let vector = "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+    // [first.org CVE-2014-0160](https://www.first.org/cvss/v3.0/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160)
+    assert_v2_base_score("AV:N/AC:L/Au:N/C:P/I:N/A:N", 5.0);
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    let calculated_temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
-    let calculated_environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // [first.org CVE-2008-1447](https://www.first.org/cvss/v3.0/examples#DNS-Kaminsky-Bug-CVE-2008-1447)
+    assert_v2_base_score("AV:N/AC:L/Au:N/C:N/I:P/A:N", 5.0);
 
-    assert_eq!(calculated_score, 6.2);
-    assert_eq!(calculated_temporal_score, 4.9);
-    assert_eq!(calculated_environmental_score, 7.5);
-}
+    // [first.org CVE-2014-2005](https://www.first.org/cvss/v3.0/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005)
+    assert_v2_base_score("AV:L/AC:M/Au:N/C:C/I:C/A:C", 6.9);
 
-#[test]
-fn test_v2_real_cve_2003_0818() {
-    // This is a real CVE with the metrics taken from the official first.org CVSS Scoring Guide examples:
-    // https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818
-    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L";
-    let cvss = CvssV2::from_str(vector).expect("Failed to parse CVSS v2.0 vector");
+    // [first.org CVE-2013-6014](https://www.first.org/cvss/v3.0/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014)
+    assert_v2_base_score("AV:A/AC:L/Au:N/C:N/I:C/A:N", 6.1);
 
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    let calculated_temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
-    let calculated_environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // [first.org CVE-2014-9253](https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253)
+    assert_v2_base_score("AV:N/AC:M/Au:N/C:N/I:P/A:N", 4.3);
 
-    assert_eq!(calculated_score, 10.0);
-    assert_eq!(calculated_temporal_score, 8.3);
-    assert_eq!(calculated_environmental_score, 9.0);
+    // [first.org CVE-2009-0658](https://www.first.org/cvss/v3.0/examples#Adobe-Acrobat-Buffer-Overflow-Vulnerability-CVE-2009-0658)
+    assert_v2_base_score("AV:N/AC:M/Au:N/C:C/I:C/A:C", 9.3);
+
+    // [first.org CVE-2011-1265](https://www.first.org/cvss/v3.0/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265)
+    assert_v2_base_score("AV:A/AC:L/Au:N/C:C/I:C/A:C", 8.3);
+
+    // [first.org CVE-2014-2019](https://www.first.org/cvss/v3.0/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019)
+    assert_v2_base_score("AV:L/AC:L/Au:N/C:N/I:C/A:N", 4.9);
+
+    // [first.org CVE-2016-0128](https://www.first.org/cvss/v3.0/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118)
+    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:N", 5.8);
+
+    // [first.org CVE-2019-7551](https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551)
+    assert_v2_base_score("AV:N/AC:M/Au:S/C:P/I:P/A:P", 6.0);
+
+    // [first.org CVE-2016-5729](https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729)
+    assert_v2_base_score("AV:L/AC:L/Au:S/C:C/I:C/A:C", 6.8);
+
+    // [first.org CVE-2015-2890](https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890)
+    assert_v2_base_score("AV:L/AC:L/Au:N/C:C/I:C/A:C", 7.2);
+
+    // [first.org CVE-2019-0884](https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884)
+    assert_v2_base_score("AV:N/AC:H/Au:N/C:C/I:C/A:C", 7.6);
 }

--- a/tests/score_calculation_tests/v2_tests.rs
+++ b/tests/score_calculation_tests/v2_tests.rs
@@ -18,8 +18,8 @@ fn assert_v2_scores(
     expected_temporal: Option<f64>,
     expected_environmental: Option<f64>,
 ) {
-    let cvss =
-        CvssV2::from_str(vector).expect(&format!("Failed to parse CVSS v2 vector: {}", vector));
+    let cvss = CvssV2::from_str(vector)
+        .unwrap_or_else(|_| panic!("Failed to parse CVSS v2 vector: {}", vector));
 
     let calculated_base = cvss
         .calculated_base_score()

--- a/tests/score_calculation_tests/v2_tests.rs
+++ b/tests/score_calculation_tests/v2_tests.rs
@@ -95,7 +95,7 @@ fn test_v2_zero_impact_score() {
 /// These are real CVEs with the metrics taken from the official first.org CVSS examples.
 #[test]
 fn test_real_cves() {
-    // [first.org CVE-2002-0392](https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392)
+    // https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392
     assert_v2_scores(
         "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H",
         7.8,
@@ -103,7 +103,7 @@ fn test_real_cves() {
         Some(9.2),
     );
 
-    // [first.org CVE-2003-0062](https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062)
+    // https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062
     assert_v2_scores(
         "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M",
         6.2,
@@ -111,7 +111,7 @@ fn test_real_cves() {
         Some(7.5),
     );
 
-    // [first.org CVE-2003-0818](https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818)
+    // https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818
     assert_v2_scores(
         "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L",
         10.0,
@@ -119,60 +119,60 @@ fn test_real_cves() {
         Some(9.0),
     );
 
-    // [first.org CVE-2013-1937](https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937)
+    // https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
     assert_v2_base_score("AV:N/AC:L/Au:S/C:P/I:P/A:N", 5.5);
 
-    // [first.org CVE-2014-3566](https://www.first.org/cvss/v3.0/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566)
+    // https://www.first.org/cvss/v3.0/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
     assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:N/A:N", 4.3);
 
-    // [first.org CVE-2012-1516](https://www.first.org/cvss/v3.0/examples#VMware-Guest-to-Host-Escape-Vulnerability-CVE-2012-1516)
+    // https://www.first.org/cvss/v3.0/examples#VMware-Guest-to-Host-Escape-Vulnerability-CVE-2012-1516
     assert_v2_base_score("AV:N/AC:L/Au:S/C:C/I:C/A:C", 9.0);
 
-    // [first.org CVE-2009-0783](https://www.first.org/cvss/v3.0/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783)
+    // https://www.first.org/cvss/v3.0/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
     assert_v2_base_score("AV:L/AC:L/Au:N/C:P/I:P/A:P", 4.6);
 
-    // [first.org CVE-2012-0384](https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384)
+    // https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
     assert_v2_base_score("AV:N/AC:M/Au:S/C:C/I:C/A:C", 8.5);
 
-    // [first.org CVE-2015-1098](https://www.first.org/cvss/v3.0/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098)
+    // https://www.first.org/cvss/v3.0/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
     assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:P", 6.8);
 
-    // [first.org CVE-2014-0160](https://www.first.org/cvss/v3.0/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160)
+    // https://www.first.org/cvss/v3.0/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
     assert_v2_base_score("AV:N/AC:L/Au:N/C:P/I:N/A:N", 5.0);
 
-    // [first.org CVE-2008-1447](https://www.first.org/cvss/v3.0/examples#DNS-Kaminsky-Bug-CVE-2008-1447)
+    // https://www.first.org/cvss/v3.0/examples#DNS-Kaminsky-Bug-CVE-2008-1447
     assert_v2_base_score("AV:N/AC:L/Au:N/C:N/I:P/A:N", 5.0);
 
-    // [first.org CVE-2014-2005](https://www.first.org/cvss/v3.0/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005)
+    // https://www.first.org/cvss/v3.0/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
     assert_v2_base_score("AV:L/AC:M/Au:N/C:C/I:C/A:C", 6.9);
 
-    // [first.org CVE-2013-6014](https://www.first.org/cvss/v3.0/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014)
+    // https://www.first.org/cvss/v3.0/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
     assert_v2_base_score("AV:A/AC:L/Au:N/C:N/I:C/A:N", 6.1);
 
-    // [first.org CVE-2014-9253](https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253)
+    // https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
     assert_v2_base_score("AV:N/AC:M/Au:N/C:N/I:P/A:N", 4.3);
 
-    // [first.org CVE-2009-0658](https://www.first.org/cvss/v3.0/examples#Adobe-Acrobat-Buffer-Overflow-Vulnerability-CVE-2009-0658)
+    // https://www.first.org/cvss/v3.0/examples#Adobe-Acrobat-Buffer-Overflow-Vulnerability-CVE-2009-0658
     assert_v2_base_score("AV:N/AC:M/Au:N/C:C/I:C/A:C", 9.3);
 
-    // [first.org CVE-2011-1265](https://www.first.org/cvss/v3.0/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265)
+    // https://www.first.org/cvss/v3.0/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
     assert_v2_base_score("AV:A/AC:L/Au:N/C:C/I:C/A:C", 8.3);
 
-    // [first.org CVE-2014-2019](https://www.first.org/cvss/v3.0/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019)
+    // https://www.first.org/cvss/v3.0/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
     assert_v2_base_score("AV:L/AC:L/Au:N/C:N/I:C/A:N", 4.9);
 
-    // [first.org CVE-2016-0128](https://www.first.org/cvss/v3.0/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118)
+    // https://www.first.org/cvss/v3.0/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
     assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:N", 5.8);
 
-    // [first.org CVE-2019-7551](https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551)
+    // https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
     assert_v2_base_score("AV:N/AC:M/Au:S/C:P/I:P/A:P", 6.0);
 
-    // [first.org CVE-2016-5729](https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729)
+    // https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
     assert_v2_base_score("AV:L/AC:L/Au:S/C:C/I:C/A:C", 6.8);
 
-    // [first.org CVE-2015-2890](https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890)
+    // https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
     assert_v2_base_score("AV:L/AC:L/Au:N/C:C/I:C/A:C", 7.2);
 
-    // [first.org CVE-2019-0884](https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884)
+    // https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
     assert_v2_base_score("AV:N/AC:H/Au:N/C:C/I:C/A:C", 7.6);
 }

--- a/tests/score_calculation_tests/v2_tests.rs
+++ b/tests/score_calculation_tests/v2_tests.rs
@@ -1,4 +1,5 @@
 use cvss_rs::v2_0::CvssV2;
+use rstest::rstest;
 use std::str::FromStr;
 
 /// Helper function to parse a CVSS v2.0 vector and verify base, temporal, and environmental scores
@@ -17,8 +18,8 @@ fn assert_v2_scores(
     expected_temporal: Option<f64>,
     expected_environmental: Option<f64>,
 ) {
-    let cvss = CvssV2::from_str(vector)
-        .expect(&format!("Failed to parse CVSS v2 vector: {}", vector));
+    let cvss =
+        CvssV2::from_str(vector).expect(&format!("Failed to parse CVSS v2 vector: {}", vector));
 
     let calculated_base = cvss
         .calculated_base_score()
@@ -93,86 +94,84 @@ fn test_v2_zero_impact_score() {
 }
 
 /// These are real CVEs with the metrics taken from the official first.org CVSS examples.
-#[test]
-fn test_real_cves() {
-    // https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392
+/// Tests for CVEs with full scores (base, temporal, environmental).
+#[rstest]
+// https://www.first.org/cvss/v2/guide#3-3-1-CVE-2002-0392
+#[case::cve_2002_0392(
+    "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H",
+    7.8,
+    6.4,
+    9.2
+)]
+// https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062
+#[case::cve_2003_0062(
+    "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M",
+    6.2,
+    4.9,
+    7.5
+)]
+// https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818
+#[case::cve_2003_0818(
+    "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L",
+    10.0,
+    8.3,
+    9.0
+)]
+fn test_real_cve_full(
+    #[case] vector: &str,
+    #[case] expected_base: f64,
+    #[case] expected_temporal: f64,
+    #[case] expected_environmental: f64,
+) {
     assert_v2_scores(
-        "AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:H",
-        7.8,
-        Some(6.4),
-        Some(9.2),
+        vector,
+        expected_base,
+        Some(expected_temporal),
+        Some(expected_environmental),
     );
+}
 
-    // https://www.first.org/cvss/v2/guide#3-3-3-CVE-2003-0062
-    assert_v2_scores(
-        "AV:L/AC:H/Au:N/C:C/I:C/A:C/E:POC/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:M",
-        6.2,
-        Some(4.9),
-        Some(7.5),
-    );
-
-    // https://www.first.org/cvss/v2/guide#3-3-2-CVE-2003-0818
-    assert_v2_scores(
-        "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:M/IR:M/AR:L",
-        10.0,
-        Some(8.3),
-        Some(9.0),
-    );
-
-    // https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
-    assert_v2_base_score("AV:N/AC:L/Au:S/C:P/I:P/A:N", 5.5);
-
-    // https://www.first.org/cvss/v3.0/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
-    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:N/A:N", 4.3);
-
-    // https://www.first.org/cvss/v3.0/examples#VMware-Guest-to-Host-Escape-Vulnerability-CVE-2012-1516
-    assert_v2_base_score("AV:N/AC:L/Au:S/C:C/I:C/A:C", 9.0);
-
-    // https://www.first.org/cvss/v3.0/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
-    assert_v2_base_score("AV:L/AC:L/Au:N/C:P/I:P/A:P", 4.6);
-
-    // https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
-    assert_v2_base_score("AV:N/AC:M/Au:S/C:C/I:C/A:C", 8.5);
-
-    // https://www.first.org/cvss/v3.0/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
-    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:P", 6.8);
-
-    // https://www.first.org/cvss/v3.0/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
-    assert_v2_base_score("AV:N/AC:L/Au:N/C:P/I:N/A:N", 5.0);
-
-    // https://www.first.org/cvss/v3.0/examples#DNS-Kaminsky-Bug-CVE-2008-1447
-    assert_v2_base_score("AV:N/AC:L/Au:N/C:N/I:P/A:N", 5.0);
-
-    // https://www.first.org/cvss/v3.0/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
-    assert_v2_base_score("AV:L/AC:M/Au:N/C:C/I:C/A:C", 6.9);
-
-    // https://www.first.org/cvss/v3.0/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
-    assert_v2_base_score("AV:A/AC:L/Au:N/C:N/I:C/A:N", 6.1);
-
-    // https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
-    assert_v2_base_score("AV:N/AC:M/Au:N/C:N/I:P/A:N", 4.3);
-
-    // https://www.first.org/cvss/v3.0/examples#Adobe-Acrobat-Buffer-Overflow-Vulnerability-CVE-2009-0658
-    assert_v2_base_score("AV:N/AC:M/Au:N/C:C/I:C/A:C", 9.3);
-
-    // https://www.first.org/cvss/v3.0/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
-    assert_v2_base_score("AV:A/AC:L/Au:N/C:C/I:C/A:C", 8.3);
-
-    // https://www.first.org/cvss/v3.0/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
-    assert_v2_base_score("AV:L/AC:L/Au:N/C:N/I:C/A:N", 4.9);
-
-    // https://www.first.org/cvss/v3.0/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
-    assert_v2_base_score("AV:N/AC:M/Au:N/C:P/I:P/A:N", 5.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
-    assert_v2_base_score("AV:N/AC:M/Au:S/C:P/I:P/A:P", 6.0);
-
-    // https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
-    assert_v2_base_score("AV:L/AC:L/Au:S/C:C/I:C/A:C", 6.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
-    assert_v2_base_score("AV:L/AC:L/Au:N/C:C/I:C/A:C", 7.2);
-
-    // https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
-    assert_v2_base_score("AV:N/AC:H/Au:N/C:C/I:C/A:C", 7.6);
+/// These are real CVEs with the metrics taken from the official first.org CVSS examples.
+/// Tests for CVEs with base score only.
+#[rstest]
+// https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
+#[case::cve_2013_1937("AV:N/AC:L/Au:S/C:P/I:P/A:N", 5.5)]
+// https://www.first.org/cvss/v3.0/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
+#[case::cve_2014_3566("AV:N/AC:M/Au:N/C:P/I:N/A:N", 4.3)]
+// https://www.first.org/cvss/v3.0/examples#VMware-Guest-to-Host-Escape-Vulnerability-CVE-2012-1516
+#[case::cve_2012_1516("AV:N/AC:L/Au:S/C:C/I:C/A:C", 9.0)]
+// https://www.first.org/cvss/v3.0/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
+#[case::cve_2009_0783("AV:L/AC:L/Au:N/C:P/I:P/A:P", 4.6)]
+// https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+#[case::cve_2012_0384("AV:N/AC:M/Au:S/C:C/I:C/A:C", 8.5)]
+// https://www.first.org/cvss/v3.0/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
+#[case::cve_2015_1098("AV:N/AC:M/Au:N/C:P/I:P/A:P", 6.8)]
+// https://www.first.org/cvss/v3.0/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
+#[case::cve_2014_0160("AV:N/AC:L/Au:N/C:P/I:N/A:N", 5.0)]
+// https://www.first.org/cvss/v3.0/examples#DNS-Kaminsky-Bug-CVE-2008-1447
+#[case::cve_2008_1447("AV:N/AC:L/Au:N/C:N/I:P/A:N", 5.0)]
+// https://www.first.org/cvss/v3.0/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
+#[case::cve_2014_2005("AV:L/AC:M/Au:N/C:C/I:C/A:C", 6.9)]
+// https://www.first.org/cvss/v3.0/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
+#[case::cve_2013_6014("AV:A/AC:L/Au:N/C:N/I:C/A:N", 6.1)]
+// https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
+#[case::cve_2014_9253("AV:N/AC:M/Au:N/C:N/I:P/A:N", 4.3)]
+// https://www.first.org/cvss/v3.0/examples#Adobe-Acrobat-Buffer-Overflow-Vulnerability-CVE-2009-0658
+#[case::cve_2009_0658("AV:N/AC:M/Au:N/C:C/I:C/A:C", 9.3)]
+// https://www.first.org/cvss/v3.0/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
+#[case::cve_2011_1265("AV:A/AC:L/Au:N/C:C/I:C/A:C", 8.3)]
+// https://www.first.org/cvss/v3.0/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
+#[case::cve_2014_2019("AV:L/AC:L/Au:N/C:N/I:C/A:N", 4.9)]
+// https://www.first.org/cvss/v3.0/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+#[case::cve_2016_0128("AV:N/AC:M/Au:N/C:P/I:P/A:N", 5.8)]
+// https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
+#[case::cve_2019_7551("AV:N/AC:M/Au:S/C:P/I:P/A:P", 6.0)]
+// https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
+#[case::cve_2016_5729("AV:L/AC:L/Au:S/C:C/I:C/A:C", 6.8)]
+// https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
+#[case::cve_2015_2890("AV:L/AC:L/Au:N/C:C/I:C/A:C", 7.2)]
+// https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
+#[case::cve_2019_0884("AV:N/AC:H/Au:N/C:C/I:C/A:C", 7.6)]
+fn test_real_cve_base_only(#[case] vector: &str, #[case] expected_base: f64) {
+    assert_v2_scores(vector, expected_base, None, None);
 }

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -18,8 +18,8 @@ fn assert_v3_scores(
     expected_temporal: Option<f64>,
     expected_environmental: Option<f64>,
 ) {
-    let cvss =
-        CvssV3::from_str(vector).expect(&format!("Failed to parse CVSS v3 vector: {}", vector));
+    let cvss = CvssV3::from_str(vector)
+        .unwrap_or_else(|_| panic!("Failed to parse CVSS v3 vector: {}", vector));
 
     let calculated_base = cvss
         .calculated_base_score()

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -1,106 +1,201 @@
 use cvss_rs::v3::CvssV3;
 use std::str::FromStr;
 
+/// Helper function to parse a CVSS v3 vector and verify base, temporal, and environmental scores
+///
+/// This function parses the provided CVSS v3 vector string and checks for each of the expected scores
+/// provided (base, temporal, environmental) if the calculated score matches the expected score.
+///
+/// Arguments:
+/// - `vector`: The CVSS v3 vector string to parse and evaluate
+/// - `expected_base`: The expected base score
+/// - `expected_temporal`: Optional expected temporal score
+/// - `expected_environmental`: Optional expected environmental score
+fn assert_v3_scores(
+    vector: &str,
+    expected_base: f64,
+    expected_temporal: Option<f64>,
+    expected_environmental: Option<f64>,
+) {
+    let cvss = CvssV3::from_str(vector)
+        .expect(&format!("Failed to parse CVSS v3 vector: {}", vector));
+
+    let calculated_base = cvss
+        .calculated_base_score()
+        .expect("Failed to calculate base score");
+    assert_eq!(
+        calculated_base, expected_base,
+        "Base score mismatch for vector: {}. Expected: {}, Calculated: {}",
+        vector, expected_base, calculated_base
+    );
+
+    if let Some(expected_temporal) = expected_temporal {
+        let calculated_temporal = cvss
+            .calculated_temporal_score()
+            .expect("Failed to calculate temporal score");
+        assert_eq!(
+            calculated_temporal, expected_temporal,
+            "Temporal score mismatch for vector: {}. Expected: {}, Calculated: {}",
+            vector, expected_temporal, calculated_temporal
+        );
+    }
+
+    if let Some(expected_environmental) = expected_environmental {
+        let calculated_environmental = cvss
+            .calculated_environmental_score()
+            .expect("Failed to calculate environmental score");
+        assert_eq!(
+            calculated_environmental, expected_environmental,
+            "Environmental score mismatch for vector: {}. Expected: {}, Calculated: {}",
+            vector, expected_environmental, calculated_environmental
+        );
+    }
+}
+
+/// Helper function to parse a CVSS v3 vector and verify only the base score
+fn assert_v3_base_score(vector: &str, expected_base: f64) {
+    assert_v3_scores(vector, expected_base, None, None);
+}
+
 #[test]
 fn test_v3_score_calculation() {
-    // CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     // This is a critical vulnerability with base score 9.8
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
-
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    assert_eq!(calculated_score, 9.8);
+    assert_v3_scores(vector, 9.8, Some(9.8), Some(9.8));
 }
 
 #[test]
 fn test_v3_scope_changed_calculation() {
-    // CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
     // Scope changed (S:C) with low privileges required
     let vector = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
-
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
     // With scope changed, PR:L uses 0.68 instead of 0.62
-    assert_eq!(calculated_score, 9.9);
+    assert_v3_base_score(vector, 9.9);
 }
 
 #[test]
 fn test_v3_temporal_score_calculation() {
-    // CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
-
-    let base_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate base score");
-    assert_eq!(base_score, 9.8);
-
-    let temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
     // Base (9.8) * E(0.94) * RL(0.95) * RC(1.0) = 8.75... -> roundup to 8.8
-    assert_eq!(temporal_score, 8.8);
+    assert_v3_scores(vector, 9.8, Some(8.8), None);
 }
 
 #[test]
 fn test_v3_environmental_score_calculation() {
-    // CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:H/IR:H/AR:H
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:H/IR:H/AR:H";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
-
-    let base_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate base score");
-    assert_eq!(base_score, 9.8);
-
-    let environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
     // With all security requirements set to High (1.5), modified impact is capped at 0.915
     // but the final roundup still results in 9.8
-    assert_eq!(environmental_score, 9.8);
+    assert_v3_scores(vector, 9.8, None, Some(9.8));
 }
 
 #[test]
 fn test_v3_zero_impact_score() {
-    // CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
     // No impact should result in score 0.0
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
-
-    let calculated_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate score");
-    assert_eq!(calculated_score, 0.0);
+    assert_v3_base_score(vector, 0.0);
 }
 
 #[test]
-fn test_v3_cve_with_explicit_not_defined() {
+fn test_v3_cve_with_some_not_defined() {
     // This vector is based on an issue brought up here: https://github.com/scm-rs/cvss-rs/issues/9
     // This tests that explicit `NotDefined` / `X` values in the modified metrics used in the
     // environmental score calculation are handled correctly / like implicit
     // "NotDefined" values caused by absence in the vector string.
-    let vector =
+    let vector_explicit =
         "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/MAV:A/MAC:L/MPR:N/MUI:X/MS:U/CR:L/IR:H/AR:X";
-    let cvss = CvssV3::from_str(vector).expect("Failed to parse CVSS v3.1 vector");
+    assert_v3_scores(vector_explicit, 7.8, Some(7.8), Some(8.0));
+    let vector_implicit =
+        "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H/MAV:A/MAC:L/MPR:N/MS:U/CR:L/IR:H";
+    assert_v3_scores(vector_implicit, 7.8, Some(7.8), Some(8.0));
+}
 
-    let base_score = cvss
-        .calculated_base_score()
-        .expect("Failed to calculate base score");
+/// These are real CVEs with the metrics taken from the official first.org CVSS examples.
+#[test]
+fn test_real_cves() {
+    // This test only exists in the v3.0 examples.
+    // first.org v3.0 CVE-2013-1937: https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
+    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
 
-    let temporal_score = cvss
-        .calculated_temporal_score()
-        .expect("Failed to calculate temporal score");
+    // This test only exists in the v3.0 examples.
+    // first.org v3.0 CVE-2014-9253: https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
+    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N", 5.4);
 
-    let environmental_score = cvss
-        .calculated_environmental_score()
-        .expect("Failed to calculate environmental score");
+    // This was re-scored in CVSS v3.1.
+    // first.org v3.0 CVE-2012-0384: https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", 8.8);
 
-    assert_eq!(base_score, 7.8);
-    assert_eq!(temporal_score, 7.8);
-    assert_eq!(environmental_score, 8.0);
+    // first.org v3.1 CVE-2013-0375: https://www.first.org/cvss/v3.1/examples#MySQL-Stored-SQL-Injection-CVE-2013-0375
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4);
+
+    // first.org v3.1 CVE-2014-3566: https://www.first.org/cvss/v3.1/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N", 3.1);
+
+    // first.org v3.1 CVE-2009-0783: https://www.first.org/cvss/v3.1/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
+    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L", 4.2);
+
+    // v3.1 re-scored PR:L -> PR:H, resulting in score 7.2 instead of 8.8.
+    // first.org v3.1 CVE-2012-0384: https://www.first.org/cvss/v3.1/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", 7.2);
+
+    // first.org v3.1 CVE-2015-1098: https://www.first.org/cvss/v3.1/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
+    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.8);
+
+    // first.org v3.1 CVE-2014-0160: https://www.first.org/cvss/v3.1/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", 7.5);
+
+    // first.org v3.1 CVE-2008-1447: https://www.first.org/cvss/v3.1/examples#DNS-Kaminsky-Bug-CVE-2008-1447
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N", 6.8);
+
+    // first.org v3.1 CVE-2014-2005: https://www.first.org/cvss/v3.1/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
+    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 6.8);
+
+    // first.org v3.1 CVE-2010-0467: https://www.first.org/cvss/v3.1/examples#Joomla-Directory-Traversal-Vulnerability-CVE-2010-0467
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N", 5.8);
+
+    // first.org v3.1 CVE-2012-1342: https://www.first.org/cvss/v3.1/examples#Cisco-Access-Control-Bypass-Vulnerability-CVE-2012-1342
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N", 5.8);
+
+    // first.org v3.1 CVE-2013-6014: https://www.first.org/cvss/v3.1/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
+    assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H", 9.3);
+
+    // first.org v3.1 CVE-2011-1265: https://www.first.org/cvss/v3.1/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
+    assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.8);
+
+    // first.org v3.1 CVE-2014-2019: https://www.first.org/cvss/v3.1/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
+    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", 4.6);
+
+    // first.org v3.1 CVE-2015-0970: https://www.first.org/cvss/v3.1/examples#SearchBlox-Cross-Site-Request-Forgery-Vulnerability-CVE-2015-0970
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 8.8);
+
+    // first.org v3.1 CVE-2014-0224: https://www.first.org/cvss/v3.1/examples#SSL-TLS-MITM-Vulnerability-CVE-2014-0224
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N", 7.4);
+
+    // first.org v3.1 CVE-2012-5376: https://www.first.org/cvss/v3.1/examples#Google-Chrome-Sandbox-Bypass-vulnerability-CVE-2012-5376
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H", 9.6);
+
+    // first.org v3.1 CVE-2016-0128: https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N", 6.8);
+
+    // first.org v3.1 CVE-2016-2118: https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.5);
+
+    // first.org v3.1 CVE-2019-7551: https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", 9.0);
+
+    // first.org v3.1 CVE-2017-5942: https://www.first.org/cvss/v3.1/examples#WordPress-Mail-Plugin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2017-5942
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
+
+    // first.org v3.1 CVE-2016-5558: https://www.first.org/cvss/v3.1/examples#Remote-Code-Execution-in-Oracle-Outside-in-Technology-CVE-2016-5558
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L", 8.6);
+
+    // first.org v3.1 CVE-2016-5729: https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
+    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H", 8.2);
+
+    // first.org v3.1 CVE-2015-2890: https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
+    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:H", 6.0);
+
+    // first.org v3.1 CVE-2018-3652: https://www.first.org/cvss/v3.1/examples#Intel-DCI-Issue-CVE-2018-3652
+    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 7.6);
+
+    // first.org v3.1 CVE-2019-0884 on Microsoft Edge: https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
+    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N", 4.2);
 }

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -112,90 +112,90 @@ fn test_v3_cve_with_some_not_defined() {
 #[test]
 fn test_real_cves() {
     // This test only exists in the v3.0 examples.
-    // first.org v3.0 CVE-2013-1937: https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
+    // https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
     assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
 
     // This test only exists in the v3.0 examples.
-    // first.org v3.0 CVE-2014-9253: https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
+    // https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
     assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N", 5.4);
 
     // This was re-scored in CVSS v3.1.
-    // first.org v3.0 CVE-2012-0384: https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+    // https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
     assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", 8.8);
 
-    // first.org v3.1 CVE-2013-0375: https://www.first.org/cvss/v3.1/examples#MySQL-Stored-SQL-Injection-CVE-2013-0375
+    // https://www.first.org/cvss/v3.1/examples#MySQL-Stored-SQL-Injection-CVE-2013-0375
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4);
 
-    // first.org v3.1 CVE-2014-3566: https://www.first.org/cvss/v3.1/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
+    // https://www.first.org/cvss/v3.1/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N", 3.1);
 
-    // first.org v3.1 CVE-2009-0783: https://www.first.org/cvss/v3.1/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
+    // https://www.first.org/cvss/v3.1/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
     assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L", 4.2);
 
     // v3.1 re-scored PR:L -> PR:H, resulting in score 7.2 instead of 8.8.
-    // first.org v3.1 CVE-2012-0384: https://www.first.org/cvss/v3.1/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+    // https://www.first.org/cvss/v3.1/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", 7.2);
 
-    // first.org v3.1 CVE-2015-1098: https://www.first.org/cvss/v3.1/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
+    // https://www.first.org/cvss/v3.1/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
     assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.8);
 
-    // first.org v3.1 CVE-2014-0160: https://www.first.org/cvss/v3.1/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
+    // https://www.first.org/cvss/v3.1/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", 7.5);
 
-    // first.org v3.1 CVE-2008-1447: https://www.first.org/cvss/v3.1/examples#DNS-Kaminsky-Bug-CVE-2008-1447
+    // https://www.first.org/cvss/v3.1/examples#DNS-Kaminsky-Bug-CVE-2008-1447
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N", 6.8);
 
-    // first.org v3.1 CVE-2014-2005: https://www.first.org/cvss/v3.1/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
+    // https://www.first.org/cvss/v3.1/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
     assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 6.8);
 
-    // first.org v3.1 CVE-2010-0467: https://www.first.org/cvss/v3.1/examples#Joomla-Directory-Traversal-Vulnerability-CVE-2010-0467
+    // https://www.first.org/cvss/v3.1/examples#Joomla-Directory-Traversal-Vulnerability-CVE-2010-0467
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N", 5.8);
 
-    // first.org v3.1 CVE-2012-1342: https://www.first.org/cvss/v3.1/examples#Cisco-Access-Control-Bypass-Vulnerability-CVE-2012-1342
+    // https://www.first.org/cvss/v3.1/examples#Cisco-Access-Control-Bypass-Vulnerability-CVE-2012-1342
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N", 5.8);
 
-    // first.org v3.1 CVE-2013-6014: https://www.first.org/cvss/v3.1/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
+    // https://www.first.org/cvss/v3.1/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
     assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H", 9.3);
 
-    // first.org v3.1 CVE-2011-1265: https://www.first.org/cvss/v3.1/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
+    // https://www.first.org/cvss/v3.1/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
     assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.8);
 
-    // first.org v3.1 CVE-2014-2019: https://www.first.org/cvss/v3.1/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
+    // https://www.first.org/cvss/v3.1/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
     assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", 4.6);
 
-    // first.org v3.1 CVE-2015-0970: https://www.first.org/cvss/v3.1/examples#SearchBlox-Cross-Site-Request-Forgery-Vulnerability-CVE-2015-0970
+    // https://www.first.org/cvss/v3.1/examples#SearchBlox-Cross-Site-Request-Forgery-Vulnerability-CVE-2015-0970
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 8.8);
 
-    // first.org v3.1 CVE-2014-0224: https://www.first.org/cvss/v3.1/examples#SSL-TLS-MITM-Vulnerability-CVE-2014-0224
+    // https://www.first.org/cvss/v3.1/examples#SSL-TLS-MITM-Vulnerability-CVE-2014-0224
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N", 7.4);
 
-    // first.org v3.1 CVE-2012-5376: https://www.first.org/cvss/v3.1/examples#Google-Chrome-Sandbox-Bypass-vulnerability-CVE-2012-5376
+    // https://www.first.org/cvss/v3.1/examples#Google-Chrome-Sandbox-Bypass-vulnerability-CVE-2012-5376
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H", 9.6);
 
-    // first.org v3.1 CVE-2016-0128: https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+    // https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N", 6.8);
 
-    // first.org v3.1 CVE-2016-2118: https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+    // https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.5);
 
-    // first.org v3.1 CVE-2019-7551: https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
+    // https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", 9.0);
 
-    // first.org v3.1 CVE-2017-5942: https://www.first.org/cvss/v3.1/examples#WordPress-Mail-Plugin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2017-5942
+    // https://www.first.org/cvss/v3.1/examples#WordPress-Mail-Plugin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2017-5942
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
 
-    // first.org v3.1 CVE-2016-5558: https://www.first.org/cvss/v3.1/examples#Remote-Code-Execution-in-Oracle-Outside-in-Technology-CVE-2016-5558
+    // https://www.first.org/cvss/v3.1/examples#Remote-Code-Execution-in-Oracle-Outside-in-Technology-CVE-2016-5558
     assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L", 8.6);
 
-    // first.org v3.1 CVE-2016-5729: https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
+    // https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
     assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H", 8.2);
 
-    // first.org v3.1 CVE-2015-2890: https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
+    // https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
     assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:H", 6.0);
 
-    // first.org v3.1 CVE-2018-3652: https://www.first.org/cvss/v3.1/examples#Intel-DCI-Issue-CVE-2018-3652
+    // https://www.first.org/cvss/v3.1/examples#Intel-DCI-Issue-CVE-2018-3652
     assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 7.6);
 
-    // first.org v3.1 CVE-2019-0884 on Microsoft Edge: https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
+    // https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
     assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N", 4.2);
 }

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -1,4 +1,5 @@
 use cvss_rs::v3::CvssV3;
+use rstest::rstest;
 use std::str::FromStr;
 
 /// Helper function to parse a CVSS v3 vector and verify base, temporal, and environmental scores
@@ -17,8 +18,8 @@ fn assert_v3_scores(
     expected_temporal: Option<f64>,
     expected_environmental: Option<f64>,
 ) {
-    let cvss = CvssV3::from_str(vector)
-        .expect(&format!("Failed to parse CVSS v3 vector: {}", vector));
+    let cvss =
+        CvssV3::from_str(vector).expect(&format!("Failed to parse CVSS v3 vector: {}", vector));
 
     let calculated_base = cvss
         .calculated_base_score()
@@ -109,93 +110,68 @@ fn test_v3_cve_with_some_not_defined() {
 }
 
 /// These are real CVEs with the metrics taken from the official first.org CVSS examples.
-#[test]
-fn test_real_cves() {
-    // This test only exists in the v3.0 examples.
-    // https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
-    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
-
-    // This test only exists in the v3.0 examples.
-    // https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
-    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N", 5.4);
-
-    // This was re-scored in CVSS v3.1.
-    // https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
-    assert_v3_base_score("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", 8.8);
-
-    // https://www.first.org/cvss/v3.1/examples#MySQL-Stored-SQL-Injection-CVE-2013-0375
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4);
-
-    // https://www.first.org/cvss/v3.1/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N", 3.1);
-
-    // https://www.first.org/cvss/v3.1/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
-    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L", 4.2);
-
-    // v3.1 re-scored PR:L -> PR:H, resulting in score 7.2 instead of 8.8.
-    // https://www.first.org/cvss/v3.1/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", 7.2);
-
-    // https://www.first.org/cvss/v3.1/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
-    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.8);
-
-    // https://www.first.org/cvss/v3.1/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", 7.5);
-
-    // https://www.first.org/cvss/v3.1/examples#DNS-Kaminsky-Bug-CVE-2008-1447
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N", 6.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
-    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 6.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Joomla-Directory-Traversal-Vulnerability-CVE-2010-0467
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N", 5.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Cisco-Access-Control-Bypass-Vulnerability-CVE-2012-1342
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N", 5.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
-    assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H", 9.3);
-
-    // https://www.first.org/cvss/v3.1/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
-    assert_v3_base_score("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.8);
-
-    // https://www.first.org/cvss/v3.1/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
-    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", 4.6);
-
-    // https://www.first.org/cvss/v3.1/examples#SearchBlox-Cross-Site-Request-Forgery-Vulnerability-CVE-2015-0970
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 8.8);
-
-    // https://www.first.org/cvss/v3.1/examples#SSL-TLS-MITM-Vulnerability-CVE-2014-0224
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N", 7.4);
-
-    // https://www.first.org/cvss/v3.1/examples#Google-Chrome-Sandbox-Bypass-vulnerability-CVE-2012-5376
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H", 9.6);
-
-    // https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N", 6.8);
-
-    // https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.5);
-
-    // https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", 9.0);
-
-    // https://www.first.org/cvss/v3.1/examples#WordPress-Mail-Plugin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2017-5942
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1);
-
-    // https://www.first.org/cvss/v3.1/examples#Remote-Code-Execution-in-Oracle-Outside-in-Technology-CVE-2016-5558
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L", 8.6);
-
-    // https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
-    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H", 8.2);
-
-    // https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
-    assert_v3_base_score("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:H", 6.0);
-
-    // https://www.first.org/cvss/v3.1/examples#Intel-DCI-Issue-CVE-2018-3652
-    assert_v3_base_score("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 7.6);
-
-    // https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
-    assert_v3_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N", 4.2);
+/// Tests for CVEs with base score only.
+#[rstest]
+// This test only exists in the v3.0 examples.
+// https://www.first.org/cvss/v3.0/examples#phpMyAdmin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2013-1937
+#[case::cve_2013_1937_v3_0("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1)]
+// This test only exists in the v3.0 examples.
+// https://www.first.org/cvss/v3.0/examples#DokuWiki-Reflected-Cross-site-Scripting-Attack-CVE-2014-9253
+#[case::cve_2014_9253_v3_0("CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N", 5.4)]
+// This was re-scored in CVSS v3.1.
+// https://www.first.org/cvss/v3.0/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+#[case::cve_2012_0384_v3_0("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", 8.8)]
+// https://www.first.org/cvss/v3.1/examples#MySQL-Stored-SQL-Injection-CVE-2013-0375
+#[case::cve_2013_0375_v3_1("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4)]
+// https://www.first.org/cvss/v3.1/examples#SSLv3-POODLE-Vulnerability-CVE-2014-3566
+#[case::cve_2014_3566_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N", 3.1)]
+// https://www.first.org/cvss/v3.1/examples#Apache-Tomcat-XML-Parser-Vulnerability-CVE-2009-0783
+#[case::cve_2009_0783_v3_1("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L", 4.2)]
+// v3.1 re-scored PR:L -> PR:H, resulting in score 7.2 instead of 8.8.
+// https://www.first.org/cvss/v3.1/examples#Cisco-IOS-Arbitrary-Command-Execution-Vulnerability-CVE-2012-0384
+#[case::cve_2012_0384_v3_1("CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H", 7.2)]
+// https://www.first.org/cvss/v3.1/examples#Apple-iWork-Denial-of-Service-Vulnerability-CVE-2015-1098
+#[case::cve_2015_1098_v3_1("CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.8)]
+// https://www.first.org/cvss/v3.1/examples#OpenSSL-Heartbleed-Vulnerability-CVE-2014-0160
+#[case::cve_2014_0160_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", 7.5)]
+// https://www.first.org/cvss/v3.1/examples#DNS-Kaminsky-Bug-CVE-2008-1447
+#[case::cve_2008_1447_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N", 6.8)]
+// https://www.first.org/cvss/v3.1/examples#Sophos-Login-Screen-Bypass-Vulnerability-CVE-2014-2005
+#[case::cve_2014_2005_v3_1("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 6.8)]
+// https://www.first.org/cvss/v3.1/examples#Joomla-Directory-Traversal-Vulnerability-CVE-2010-0467
+#[case::cve_2010_0467_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:N", 5.8)]
+// https://www.first.org/cvss/v3.1/examples#Cisco-Access-Control-Bypass-Vulnerability-CVE-2012-1342
+#[case::cve_2012_1342_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N", 5.8)]
+// https://www.first.org/cvss/v3.1/examples#Juniper-Proxy-ARP-Denial-of-Service-Vulnerability-CVE-2013-6014
+#[case::cve_2013_6014_v3_1("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:H", 9.3)]
+// https://www.first.org/cvss/v3.1/examples#Microsoft-Windows-Bluetooth-Remote-Code-Execution-Vulnerability-CVE-2011-1265
+#[case::cve_2011_1265_v3_1("CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.8)]
+// https://www.first.org/cvss/v3.1/examples#Apple-iOS-Security-Control-Bypass-Vulnerability-CVE-2014-2019
+#[case::cve_2014_2019_v3_1("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", 4.6)]
+// https://www.first.org/cvss/v3.1/examples#SearchBlox-Cross-Site-Request-Forgery-Vulnerability-CVE-2015-0970
+#[case::cve_2015_0970_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H", 8.8)]
+// https://www.first.org/cvss/v3.1/examples#SSL-TLS-MITM-Vulnerability-CVE-2014-0224
+#[case::cve_2014_0224_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N", 7.4)]
+// https://www.first.org/cvss/v3.1/examples#Google-Chrome-Sandbox-Bypass-vulnerability-CVE-2012-5376
+#[case::cve_2012_5376_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H", 9.6)]
+// https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+#[case::cve_2016_0128_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N", 6.8)]
+// https://www.first.org/cvss/v3.1/examples#SAMR-LSAD-Privilege-Escalation-via-Protocol-Downgrade-Vulnerability-Badlock-CVE-2016-0128-and-CVE-2016-2118
+#[case::cve_2016_2118_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H", 7.5)]
+// https://www.first.org/cvss/v3.1/examples#Cantemo-Portal-Stored-Cross-site-Scripting-Vulnerability-CVE-2019-7551
+#[case::cve_2019_7551_v3_1("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", 9.0)]
+// https://www.first.org/cvss/v3.1/examples#WordPress-Mail-Plugin-Reflected-Cross-site-Scripting-Vulnerability-CVE-2017-5942
+#[case::cve_2017_5942_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1)]
+// https://www.first.org/cvss/v3.1/examples#Remote-Code-Execution-in-Oracle-Outside-in-Technology-CVE-2016-5558
+#[case::cve_2016_5558_v3_1("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L", 8.6)]
+// https://www.first.org/cvss/v3.1/examples#Lenovo-ThinkPwn-Exploit-CVE-2016-5729
+#[case::cve_2016_5729_v3_1("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:H", 8.2)]
+// https://www.first.org/cvss/v3.1/examples#Failure-to-Lock-Flash-on-Resume-from-sleep-CVE-2015-2890
+#[case::cve_2015_2890_v3_1("CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:H", 6.0)]
+// https://www.first.org/cvss/v3.1/examples#Intel-DCI-Issue-CVE-2018-3652
+#[case::cve_2018_3652_v3_1("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 7.6)]
+// https://www.first.org/cvss/v3.1/examples#Scripting-Engine-Memory-Corruption-Vulnerability-CVE-2019-0884
+#[case::cve_2019_0884_v3_1("CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N", 4.2)]
+fn test_real_cve_base_only(#[case] vector: &str, #[case] expected_base: f64) {
+    assert_v3_base_score(vector, expected_base);
 }


### PR DESCRIPTION
This is also a byproduct from bug-hunting for #9. I took all unique CVSS vectors from the 3.0 / 3.1 examples on first.org and added them as (one big) unit test for v2 and v3. If a test with the same vector exists for both 3.0 and 3.1 there, I set the version to 3.1.

There are two things here im a bit unhappy with:
* The decision to have one big method vs seperate methods for each case was based on having less clutter / overhead, for the cost of a worse test resolution. If its fine with you, I'd add a test parametrization library like rstest to fix this.

* The assertion helper functions for v2 and v3 could be easily turned into a generic, but would require another trait to expose the calculated_*_score methods. As far as I can see, exposing these will be necessary for our csaf-rs use-cases, and I propose do this refactor in a seperate PR. Otherwise, this PR containing only additional test cases would unexpectedly change the API.