### PR TITLE
fix: bump MSRV to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cvss-rs"
 version = "0.3.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 description = "A Rust library for representing and deserializing CVSS (Common Vulnerability Scoring System) data."
 license = "Apache-2.0"
 repository = "https://github.com/scm-rs/cvss-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cvss-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "A Rust library for representing and deserializing CVSS (Common Vulnerability Scoring System) data."


### PR DESCRIPTION
## Summary

- Bumps MSRV from 1.80 to 1.85 to fix CI failures
- A transitive dependency (`toml_parser v1.1.0`, via `strum_macros` → `proc-macro-crate v3.5.0`) now requires Rust edition 2024, which was stabilized in Rust 1.85
- The previous MSRV of 1.80 cannot parse the manifest for this dependency, causing the `check` job to fail

## Test plan

- [ ] CI passes on this PR
- [ ] Team confirms 1.85 is an acceptable minimum Rust version

🤖 Generated with [Claude Code](https://claude.com/claude-code)