### PR TITLE
chore: update version in README.md snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cvss-rs = "0.2"
+cvss-rs = "0.3"
 ```
 
 ## Usage


### PR DESCRIPTION
Version in the README installation snippet was out-of-sync with the latest released version.