### PR TITLE
docs: fix `cargo doc` warnings

### DIFF
--- a/src/v4_0/lookup.rs
+++ b/src/v4_0/lookup.rs
@@ -1,7 +1,7 @@
 //! Lookup tables for CVSS v4.0 MacroVector scoring.
 //!
 //! Based on the official CVSS v4.0 specification and calculator:
-//! https://github.com/FIRSTdotorg/cvss-v4-calculator
+//! <https://github.com/FIRSTdotorg/cvss-v4-calculator>
 
 use super::scoring::{MacroVector, VectorEq};
 

--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -542,7 +542,7 @@ impl CvssV4 {
     /// Returns None if required base metrics are missing.
     ///
     /// This uses the CVSS v4.0 MacroVector-based scoring algorithm as specified in:
-    /// https://www.first.org/cvss/v4.0/specification-document
+    /// <https://www.first.org/cvss/v4.0/specification-document>
     ///
     /// The score is rounded to one decimal place as required by the specification.
     ///

--- a/src/v4_0/scoring.rs
+++ b/src/v4_0/scoring.rs
@@ -1,7 +1,7 @@
 //! CVSS v4.0 scoring algorithm implementation.
 //!
 //! Implements the MacroVector-based scoring algorithm as specified in:
-//! https://www.first.org/cvss/v4.0/specification-document
+//! <https://www.first.org/cvss/v4.0/specification-document>
 
 use super::*;
 use crate::v4_0::lookup::lookup_global;


### PR DESCRIPTION
Wraps links in `<>` to make them click-able, fixes `cargo doc` warnings.

Only the link in mod.rs has an effect on the docs provided via docs.rs.