### PR TITLE
docs: install snippet uses `cargo add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@
 
 ## Installation
 
-Add this to your `Cargo.toml`:
+Run the following command:
 
-```toml
-[dependencies]
-cvss-rs = "0.3"
+```sh  
+cargo add cvss-rs
 ```
 
 ## Usage


### PR DESCRIPTION
As discussed here: https://github.com/scm-rs/cvss-rs/pull/18#issuecomment-4658975283