### PR TITLE
chore: bump strum to 0.28 and indicatif to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -25,7 +25,7 @@ serde_json = "1.0"
 [dev-dependencies]
 anyhow = "1.0"
 walkdir = "2"
-indicatif = { version = "0.17", features = ["rayon"] }
+indicatif = { version = "0.18", features = ["rayon"] }
 rayon = "1.5"
 
 [profile.walkall]


### PR DESCRIPTION
From what I've seen, none of the changes should have an impact on the project:
https://github.com/console-rs/indicatif/releases
https://github.com/Peternator7/strum/releases

Mostly QOL and fixes, the indicatif release bumps their MSRV to 1.71, but we are on 1.85 anyway.