### PR TITLE
fix: move rstest to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["parser-implementations", "data-structures", "security"]
 readme = "README.md"
 
 [dependencies]
-rstest = "0.26.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }
@@ -24,6 +23,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
+rstest = "0.26"
 walkdir = "2"
 indicatif = { version = "0.17", features = ["rayon"] }
 rayon = "1.5"


### PR DESCRIPTION
In #13, I accidentally added rstest under dependencies, while dev-dependencies would be more correct place.

This fixes this by moving it to dev-dependencies. I also dropped the patch version pinning.