### PR TITLE
feat: unify and extract prefix parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,12 +3,18 @@ use thiserror::Error;
 /// Errors that can occur when parsing CVSS vector strings.
 #[derive(Clone, Debug, PartialEq, Error)]
 pub enum ParseError {
-    /// Vector string doesn't start with "CVSS" or expected prefix
-    #[error("invalid vector prefix: expected 'CVSS', found '{found}'")]
-    InvalidPrefix { found: String },
+    /// Vector string is malformed (e.g., missing '/' separators)
+    #[error("malformed vector string: no '/' separator found")]
+    MalformedVectorString,
+    /// Vector string doesn't start with "CVSS:"
+    #[error("invalid vector prefix: expected prefix to start with 'CVSS:', found '{found}'")]
+    InvalidPrefixLabel { found: String },
+    /// CVSS version has unexpected format
+    #[error("malformed CVSS version format: '{version}' (expected 'X.Y')")]
+    MalformedPrefixVersion { version: String },
     /// Unsupported or invalid CVSS version
     #[error("invalid or unsupported CVSS version: '{version}'")]
-    InvalidVersion { version: String },
+    InvalidPrefixVersion { version: String },
     /// Component is malformed (not in key:value format)
     #[error("invalid component format: '{component}' (expected 'KEY:VALUE')")]
     InvalidComponent { component: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,17 +40,21 @@
 //!     panic!("Expected Cvss::V3_1 variant");
 //! }
 //! ```
+
 use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 use strum::{Display, EnumDiscriminants, EnumString};
+
 pub mod error;
 pub(crate) mod utils;
 pub mod v2_0;
 pub mod v3;
 pub mod v4_0;
 pub mod version;
+
 // Re-export for API stability
 pub use error::ParseError;
+
 /// An enum to hold any version of a CVSS object.
 #[derive(Debug, Deserialize, EnumDiscriminants)]
 #[serde(tag = "version")]
@@ -71,16 +75,19 @@ pub enum Cvss {
     #[strum_discriminants(strum(serialize = "4.0"))]
     V4(v4_0::CvssV4),
 }
+
 impl Display for Cvss {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.vector_string())
     }
 }
+
 impl Cvss {
     /// Returns the version of the CVSS standard.
     pub fn version(&self) -> Version {
         self.into()
     }
+
     /// Returns the CVSS vector string.
     pub fn vector_string(&self) -> &str {
         match self {
@@ -90,6 +97,7 @@ impl Cvss {
             Cvss::V4(c) => c.vector_string(),
         }
     }
+
     /// Returns the base score.
     pub fn base_score(&self) -> f64 {
         match self {
@@ -99,6 +107,7 @@ impl Cvss {
             Cvss::V4(c) => c.base_score(),
         }
     }
+
     /// Returns the base severity.
     pub fn base_severity(&self) -> Option<Severity> {
         match self {
@@ -109,6 +118,7 @@ impl Cvss {
         }
     }
 }
+
 /// Represents the qualitative severity rating of a vulnerability.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "UPPERCASE")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,20 +40,17 @@
 //!     panic!("Expected Cvss::V3_1 variant");
 //! }
 //! ```
-
 use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 use strum::{Display, EnumDiscriminants, EnumString};
-
 pub mod error;
+pub(crate) mod utils;
 pub mod v2_0;
 pub mod v3;
 pub mod v4_0;
 pub mod version;
-
 // Re-export for API stability
 pub use error::ParseError;
-
 /// An enum to hold any version of a CVSS object.
 #[derive(Debug, Deserialize, EnumDiscriminants)]
 #[serde(tag = "version")]
@@ -62,27 +59,28 @@ pub use error::ParseError;
 #[strum_discriminants(derive(Display, EnumString))]
 pub enum Cvss {
     #[serde(rename = "2.0")]
+    #[strum_discriminants(strum(serialize = "2.0"))]
     V2(v2_0::CvssV2),
     #[serde(rename = "3.0")]
+    #[strum_discriminants(strum(serialize = "3.0"))]
     V3_0(v3::CvssV3),
     #[serde(rename = "3.1")]
+    #[strum_discriminants(strum(serialize = "3.1"))]
     V3_1(v3::CvssV3),
     #[serde(rename = "4.0")]
+    #[strum_discriminants(strum(serialize = "4.0"))]
     V4(v4_0::CvssV4),
 }
-
 impl Display for Cvss {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.vector_string())
     }
 }
-
 impl Cvss {
     /// Returns the version of the CVSS standard.
     pub fn version(&self) -> Version {
         self.into()
     }
-
     /// Returns the CVSS vector string.
     pub fn vector_string(&self) -> &str {
         match self {
@@ -92,7 +90,6 @@ impl Cvss {
             Cvss::V4(c) => c.vector_string(),
         }
     }
-
     /// Returns the base score.
     pub fn base_score(&self) -> f64 {
         match self {
@@ -102,7 +99,6 @@ impl Cvss {
             Cvss::V4(c) => c.base_score(),
         }
     }
-
     /// Returns the base severity.
     pub fn base_severity(&self) -> Option<Severity> {
         match self {
@@ -113,7 +109,6 @@ impl Cvss {
         }
     }
 }
-
 /// Represents the qualitative severity rating of a vulnerability.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "UPPERCASE")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,3 @@
+//! Utility modules for CVSS parsing and validation.
+
+pub(crate) mod prefix;

--- a/src/utils/prefix.rs
+++ b/src/utils/prefix.rs
@@ -1,0 +1,379 @@
+//! Utilities for validating and parsing CVSS vector prefixes.
+
+use crate::{ParseError, Version};
+use std::str::FromStr;
+
+/// Validates and parses a CVSS vector prefix into a [`Version`].
+///
+/// This is a shared internal function used by the CVSS v2, v3, and v4 parsers.
+///
+/// # Arguments
+/// * `prefix_component` - A string expected to be in the format `CVSS:X.Y`, where:
+///   - The label `CVSS` must be in uppercase
+///   - `X.Y` is a version number (one of: `2.0`, `3.0`, `3.1`, or `4.0`)
+///
+/// # Returns
+/// * `Ok(`[`Version`]`)` - The validated CVSS version
+/// * `Err(`[`ParseError::InvalidPrefixLabel`]`)` - The prefix label is not exactly `CVSS` or the prefix is missing
+/// * `Err(`[`ParseError::MalformedPrefixVersion`]`)` - The version component doesn't match `X.Y` format
+/// * `Err(`[`ParseError::InvalidPrefixVersion`]`)` - The version `X.Y` is not a recognized CVSS version
+fn validate_prefix(prefix_component: &str) -> Result<Version, ParseError> {
+    // split the input on the first ':' into prefix and version string
+    // if there is no ':', return an InvalidPrefixLabel error
+    let (label_str, version_str) =
+        prefix_component
+            .split_once(':')
+            .ok_or_else(|| ParseError::InvalidPrefixLabel {
+                found: prefix_component.to_string(),
+            })?;
+
+    // the prefix must be exactly 'CVSS' in uppercase, else return an InvalidPrefixLabel error
+    if label_str != "CVSS" {
+        return Err(ParseError::InvalidPrefixLabel {
+            found: prefix_component.to_string(),
+        });
+    }
+
+    // version string must have 'X.Y' structure where X and Y are ASCII digits
+    let version_bytes = version_str.as_bytes();
+    let version_has_valid_structure = version_bytes.len() == 3
+        && version_bytes[0].is_ascii_digit()
+        && version_bytes[1] == b'.'
+        && version_bytes[2].is_ascii_digit();
+    if !version_has_valid_structure {
+        return Err(ParseError::MalformedPrefixVersion {
+            version: prefix_component.to_string(),
+        });
+    }
+
+    // version string must be one of the known versions
+    Version::from_str(version_str).map_err(|_| ParseError::InvalidPrefixVersion {
+        version: version_str.to_string(),
+    })
+}
+
+/// Splits a CVSS vector string on the first `'/'` separator.
+///
+/// # Returns
+/// * `Ok((first_component, remaining_components))`
+/// * `Err(`[`ParseError::MalformedVectorString`]`)` - No `'/'` separator was found in the vector
+#[inline]
+fn split_vector(vector: &str) -> Result<(&str, &str), ParseError> {
+    vector
+        .split_once('/')
+        .ok_or(ParseError::MalformedVectorString)
+}
+
+/// Extracts and validates a CVSS version prefix from a vector string.
+///
+/// Used by CVSS v3 and v4 parsers where the prefix is required.
+///
+/// # Arguments
+/// * `vector` - A CVSS vector
+///
+/// # Returns
+/// * `Ok((`[`Version`]`, remaining_metrics))` - The prefix was valid; `remaining_metrics` contains the metric key-value pairs
+/// * `Err(`[`ParseError::MalformedVectorString`]`)` - The vector has no `'/'` separator
+/// * `Err(`[`ParseError::InvalidPrefixLabel`]`)` - The first component is not a valid CVSS prefix
+/// * `Err(`[`ParseError::MalformedPrefixVersion`]`)` - The prefix exists but the version format is invalid
+/// * `Err(`[`ParseError::InvalidPrefixVersion`]`)` - The prefix version is not a supported CVSS version
+pub(crate) fn extract_version_from_required_prefix(
+    vector: &str,
+) -> Result<(Version, &str), ParseError> {
+    let (first_component, remaining_components) = split_vector(vector)?;
+
+    // if the version prefix is missing, first_component contains some metric KVP, which will
+    // result in an InvalidPrefixLabel error
+    let version = validate_prefix(first_component)?;
+
+    Ok((version, remaining_components))
+}
+
+/// Tries to extract a CVSS version prefix from a vector string, allowing for an optional prefix.
+///
+/// Used by the CVSS v2 parser, where the prefix is optional. If a prefix-like
+/// component is detected (starts with `cvss:` case-insensitively), it is validated. Otherwise, the entire
+/// vector is returned as metrics.
+///
+/// # Arguments
+/// * `vector` - A CVSS vector
+///
+/// # Returns
+/// * `Ok((Some(`[`Version`]`), remaining_metrics))` - A valid CVSS prefix was found and parsed
+/// * `Ok((None, vector))` - No prefix was detected; the vector is returned as-is for metric parsing
+/// * `Err(`[`ParseError::MalformedVectorString`]`)` - The vector has no `'/'` separator
+/// * `Err(`[`ParseError::InvalidPrefixLabel`]`)` - A prefix-like component exists but fails validation
+/// * `Err(`[`ParseError::MalformedPrefixVersion`]`)` - A prefix exists but the version format is invalid
+/// * `Err(`[`ParseError::InvalidPrefixVersion`]`)` - A prefix exists but the version is not supported
+pub(crate) fn extract_version_from_optional_prefix(
+    vector: &str,
+) -> Result<(Option<Version>, &str), ParseError> {
+    let (first_component, remaining_components) = split_vector(vector)?;
+
+    // check if the first component key is case-insensitive `cvss:`
+    // if so, we assume the first element to be a cvss prefix, and validate it
+    let is_prefix_like = first_component
+        .get(..5)
+        .is_some_and(|s| s.eq_ignore_ascii_case("cvss:"));
+    if is_prefix_like {
+        let version = validate_prefix(first_component)?;
+        Ok((Some(version), remaining_components))
+    } else {
+        Ok((None, vector))
+    }
+}
+
+/// Validates that a parsed CVSS version is supported in the current parser context.
+///
+/// # Arguments
+/// * `version` - The [`Version`] to validate
+/// * `allowed_versions` - A slice of allowed [`Version`] values for the current context
+///
+/// # Returns
+/// * `Ok(())` - The version is in the allowed list
+/// * `Err(`[`ParseError::InvalidPrefixVersion`]`)` - The version is not allowed in this context
+pub(crate) fn validate_allowed_prefix_version(
+    version: &Version,
+    allowed_versions: &[Version],
+) -> Result<(), ParseError> {
+    if allowed_versions.contains(version) {
+        Ok(())
+    } else {
+        Err(ParseError::InvalidPrefixVersion {
+            version: version.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod split_vector_tests {
+    use super::*;
+
+    #[test]
+    fn test_split_vector_valid() {
+        let (first, rest) = split_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H").unwrap();
+        assert_eq!(first, "CVSS:3.1");
+        assert_eq!(rest, "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+    }
+
+    #[test]
+    fn test_split_vector_invalid_only_prefix() {
+        let result = split_vector("CVSS:3.1");
+        assert!(matches!(result, Err(ParseError::MalformedVectorString)));
+    }
+
+    #[test]
+    fn test_split_vector_invalid_empty() {
+        let result = split_vector("");
+        assert!(matches!(result, Err(ParseError::MalformedVectorString)));
+    }
+
+    #[test]
+    fn test_split_vector_valid_v2_vector_no_prefix() {
+        let (first, rest) = split_vector("AV:N/AC:L/Au:N/C:N/I:N/A:N").unwrap();
+        assert_eq!(first, "AV:N");
+        assert_eq!(rest, "AC:L/Au:N/C:N/I:N/A:N");
+    }
+}
+
+#[cfg(test)]
+mod validate_prefix_tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("CVSS:2.0", Version::V2)]
+    #[case("CVSS:3.0", Version::V3_0)]
+    #[case("CVSS:3.1", Version::V3_1)]
+    #[case("CVSS:4.0", Version::V4)]
+    fn test_valid_prefixes(#[case] input: &str, #[case] expected: Version) {
+        assert_eq!(validate_prefix(input).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case("cvss:2.0")]
+    #[case("CvSs:2.0")]
+    #[case("CVSS2.0")]
+    #[case("CVSS-2.0")]
+    fn test_invalid_prefix_cases(#[case] input: &str) {
+        let result = validate_prefix(input);
+        assert!(matches!(result, Err(ParseError::InvalidPrefixLabel { .. })));
+    }
+
+    #[rstest]
+    #[case("CVSS:")]
+    #[case("CVSS:3")]
+    #[case("CVSS:2.0:extra")]
+    fn test_malformed_version_cases(#[case] input: &str) {
+        let result = validate_prefix(input);
+        assert!(matches!(
+            result,
+            Err(ParseError::MalformedPrefixVersion { .. })
+        ));
+    }
+
+    #[rstest]
+    #[case("CVSS:2.9")]
+    #[case("CVSS:3.2")]
+    #[case("CVSS:4.9")]
+    #[case("CVSS:5.0")]
+    fn test_invalid_version_cases(#[case] input: &str) {
+        let result = validate_prefix(input);
+        assert!(matches!(
+            result,
+            Err(ParseError::InvalidPrefixVersion { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod extract_required_version_component_tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        Version::V3_0,
+        "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    )]
+    #[case(
+        "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        Version::V3_1,
+        "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    )]
+    #[case(
+        "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H",
+        Version::V4,
+        "AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H"
+    )]
+    fn test_valid_vectors(
+        #[case] input: &str,
+        #[case] expected_version: Version,
+        #[case] expected_remaining: &str,
+    ) {
+        let (version, remaining) = extract_version_from_required_prefix(input).unwrap();
+        assert_eq!(version, expected_version);
+        assert_eq!(remaining, expected_remaining);
+    }
+
+    #[test]
+    fn test_invalid_only_prefix() {
+        let result = extract_version_from_required_prefix("CVSS:3.1");
+        assert!(matches!(result, Err(ParseError::MalformedVectorString)));
+    }
+
+    #[test]
+    fn test_invalid_missing_prefix() {
+        let result = extract_version_from_required_prefix("AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        assert!(matches!(result, Err(ParseError::InvalidPrefixLabel { .. })));
+    }
+
+    #[test]
+    fn test_invalid_invalid_prefix_label() {
+        let result =
+            extract_version_from_required_prefix("cvss:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        assert!(matches!(result, Err(ParseError::InvalidPrefixLabel { .. })));
+    }
+
+    #[test]
+    fn test_malformed_prefix_version() {
+        let result =
+            extract_version_from_required_prefix("CVSS:3/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        assert!(matches!(
+            result,
+            Err(ParseError::MalformedPrefixVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn test_invalid_invalid_prefix_version() {
+        let result =
+            extract_version_from_required_prefix("CVSS:3.2/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        assert!(matches!(
+            result,
+            Err(ParseError::InvalidPrefixVersion { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod extract_version_from_optional_prefix_tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C",
+        Some(Version::V2),
+        "AV:N/AC:L/Au:N/C:C/I:C/A:C"
+    )]
+    #[case("AV:N/AC:L/Au:N/C:C/I:C/A:C", None, "AV:N/AC:L/Au:N/C:C/I:C/A:C")]
+    fn test_valid_vectors_with_prefix(
+        #[case] input: &str,
+        #[case] expected_version: Option<Version>,
+        #[case] expected_remaining: &str,
+    ) {
+        let (version, remaining) = extract_version_from_optional_prefix(input).unwrap();
+        assert_eq!(version, expected_version);
+        assert_eq!(remaining, expected_remaining);
+    }
+
+    #[test]
+    fn test_only_prefix_no_slash() {
+        let result = extract_version_from_optional_prefix("CVSS:2.0");
+        assert!(matches!(result, Err(ParseError::MalformedVectorString)));
+    }
+
+    #[test]
+    fn test_lowercase_prefix_label() {
+        let result = extract_version_from_optional_prefix("cvss:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C");
+        assert!(matches!(result, Err(ParseError::InvalidPrefixLabel { .. })));
+    }
+
+    #[test]
+    fn test_invalid_prefix_version() {
+        let result = extract_version_from_optional_prefix("CVSS:2.9/AV:N/AC:L/Au:N/C:C/I:C/A:C");
+        assert!(matches!(
+            result,
+            Err(ParseError::InvalidPrefixVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn test_malformed_prefix_version() {
+        let result = extract_version_from_optional_prefix("CVSS:2/AV:N/AC:L/Au:N/C:C/I:C/A:C");
+        assert!(matches!(
+            result,
+            Err(ParseError::MalformedPrefixVersion { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod validate_allowed_prefix_version_tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(&Version::V3_1, &[Version::V3_1], true)]
+    #[case(&Version::V3_1, &[Version::V4], false)]
+    #[case(&Version::V3_1, &[Version::V3_1, Version::V4], true)]
+    #[case(&Version::V3_1, &[Version::V3_0, Version::V4], false)]
+    fn test_validate_allowed_prefix_version(
+        #[case] version: &Version,
+        #[case] allowed_versions: &[Version],
+        #[case] should_be_ok: bool,
+    ) {
+        let result = validate_allowed_prefix_version(version, allowed_versions);
+
+        if should_be_ok {
+            assert!(result.is_ok());
+        } else {
+            assert!(matches!(
+                result,
+                Err(ParseError::InvalidPrefixVersion { .. })
+            ));
+        }
+    }
+}

--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
+use crate::utils::prefix;
+use crate::Version;
 use crate::{ParseError, Severity as UnifiedSeverity};
 
 /// Represents a CVSS v2.0 score object.
@@ -552,16 +554,13 @@ impl FromStr for CvssV2 {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let components_str = s;
+        // try to extract version prefix and extract components
+        let (version_opt, components_str) = prefix::extract_version_from_optional_prefix(s)?;
 
-        // CVSS v2 vectors may or may not have "CVSS:2.0/" prefix
-        // Examples: "AV:N/AC:L/Au:N/C:C/I:C/A:C" or "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C"
-        let components_str =
-            if components_str.starts_with("CVSS:2.0/") || components_str.starts_with("cvss:2.0/") {
-                &components_str[9..] // Skip "CVSS:2.0/"
-            } else {
-                components_str
-            };
+        // if a prefix exists, its version must be 2.0
+        if let Some(version) = version_opt {
+            prefix::validate_allowed_prefix_version(&version, &[Version::V2])?;
+        }
 
         let mut cvss = CvssV2 {
             vector_string: s.to_string(),

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -5,7 +5,10 @@ use std::fmt;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
-use crate::{version::VersionV3, ParseError, Severity as UnifiedSeverity};
+use crate::utils::prefix;
+use crate::version::VersionV3;
+use crate::Version;
+use crate::{ParseError, Severity as UnifiedSeverity};
 
 /// Represents a CVSS v3.0 or v3.1 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -603,40 +606,17 @@ impl FromStr for CvssV3 {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut components = s.split('/');
+        // extract and validate version prefix
+        let (version, components_str) = prefix::extract_version_from_required_prefix(s)?;
 
-        // Parse version prefix (e.g., "CVSS:3.1")
-        let version_component = components.next().ok_or_else(|| ParseError::InvalidPrefix {
-            found: String::new(),
-        })?;
+        // validate that the prefix version is either 3.0 or 3.1
+        prefix::validate_allowed_prefix_version(&version, &[Version::V3_0, Version::V3_1])?;
 
-        let mut version_parts = version_component.split(':');
-        let prefix = version_parts
-            .next()
-            .ok_or_else(|| ParseError::InvalidPrefix {
-                found: version_component.to_string(),
-            })?;
-
-        if !prefix.eq_ignore_ascii_case("CVSS") {
-            return Err(ParseError::InvalidPrefix {
-                found: prefix.to_string(),
-            });
-        }
-
-        let version_str = version_parts
-            .next()
-            .ok_or_else(|| ParseError::InvalidVersion {
-                version: version_component.to_string(),
-            })?;
-
-        let parsed_version = match version_str {
-            "3.0" => VersionV3::V3_0,
-            "3.1" => VersionV3::V3_1,
-            _ => {
-                return Err(ParseError::InvalidVersion {
-                    version: version_str.to_string(),
-                })
-            }
+        // map to tightened version enum
+        let parsed_version = match version {
+            Version::V3_0 => VersionV3::V3_0,
+            Version::V3_1 => VersionV3::V3_1,
+            _ => unreachable!("validated above"),
         };
 
         // Initialize a CvssV3 with empty fields
@@ -674,7 +654,7 @@ impl FromStr for CvssV3 {
         };
 
         // Parse metrics
-        for component in components {
+        for component in components_str.split('/') {
             if component.is_empty() {
                 continue;
             }

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -5,10 +5,7 @@ use std::fmt;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
-use crate::utils::prefix;
-use crate::version::VersionV3;
-use crate::Version;
-use crate::{ParseError, Severity as UnifiedSeverity};
+use crate::{utils::prefix, version::VersionV3, ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v3.0 or v3.1 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
+use crate::utils::prefix;
+use crate::Version;
 use crate::{ParseError, Severity as UnifiedSeverity};
 
 /// Represents a CVSS v4.0 score object.
@@ -589,37 +591,11 @@ impl FromStr for CvssV4 {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut components = s.split('/');
+        // Extract and validate version prefix
+        let (version, components_str) = prefix::extract_version_from_required_prefix(s)?;
 
-        // Parse version prefix (e.g., "CVSS:4.0")
-        let version_component = components.next().ok_or_else(|| ParseError::InvalidPrefix {
-            found: String::new(),
-        })?;
-
-        let mut version_parts = version_component.split(':');
-        let prefix = version_parts
-            .next()
-            .ok_or_else(|| ParseError::InvalidPrefix {
-                found: version_component.to_string(),
-            })?;
-
-        if !prefix.eq_ignore_ascii_case("CVSS") {
-            return Err(ParseError::InvalidPrefix {
-                found: prefix.to_string(),
-            });
-        }
-
-        let version = version_parts
-            .next()
-            .ok_or_else(|| ParseError::InvalidVersion {
-                version: version_component.to_string(),
-            })?;
-
-        if version != "4.0" {
-            return Err(ParseError::InvalidVersion {
-                version: version.to_string(),
-            });
-        }
+        // Must be 4.0
+        prefix::validate_allowed_prefix_version(&version, &[Version::V4])?;
 
         // Initialize a CvssV4 with empty fields
         let mut cvss = CvssV4 {
@@ -661,7 +637,7 @@ impl FromStr for CvssV4 {
         };
 
         // Parse metrics
-        for component in components {
+        for component in components_str.split('/') {
             if component.is_empty() {
                 continue;
             }

--- a/tests/vector_validation_tests.rs
+++ b/tests/vector_validation_tests.rs
@@ -1,0 +1,5 @@
+mod vector_validation_tests {
+    mod v2_tests;
+    mod v3_tests;
+    mod v4_tests;
+}

--- a/tests/vector_validation_tests/v2_tests.rs
+++ b/tests/vector_validation_tests/v2_tests.rs
@@ -1,0 +1,88 @@
+use cvss_rs as cvss;
+use std::str::FromStr;
+
+#[test]
+fn test_v2_0_valid_with_prefix() {
+    let vector = "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let cvss = cvss::v2_0::CvssV2::from_str(vector)
+        .expect("should parse valid v2.0 vector with CVSS:2.0 prefix");
+
+    assert_eq!(cvss.vector_string, vector);
+    assert_eq!(cvss.access_vector, Some(cvss::v2_0::AccessVector::Network));
+}
+
+#[test]
+fn test_v2_0_valid_without_prefix() {
+    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let cvss = cvss::v2_0::CvssV2::from_str(vector)
+        .expect("should parse valid v2.0 vector without prefix");
+
+    assert_eq!(cvss.vector_string, vector);
+    assert_eq!(cvss.access_vector, Some(cvss::v2_0::AccessVector::Network));
+}
+
+#[test]
+fn test_v2_0_invalid_lowercase_prefix() {
+    let vector = "cvss:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v2_0_invalid_mixed_case_prefix() {
+    let vector = "CvSs:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v2_0_invalid_prefix_version() {
+    let vector = "CVSS:2.9/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v2_0_invalid_malformed_prefix_version() {
+    let vector = "CVSS:2/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v2_0_parser_fails_on_v_3_1_vector() {
+    let vector = "CVSS:3.1/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v2_0_invalid_malformed_vector() {
+    let vector = "THIS:JUSTISNTACVSSVECTOR";
+    let result = cvss::v2_0::CvssV2::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedVectorString)
+    ));
+}

--- a/tests/vector_validation_tests/v3_tests.rs
+++ b/tests/vector_validation_tests/v3_tests.rs
@@ -1,0 +1,89 @@
+use cvss_rs as cvss;
+use std::str::FromStr;
+
+#[test]
+fn test_v3_1_valid_prefix() {
+    let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let cvss = cvss::v3::CvssV3::from_str(vector)
+        .expect("should parse valid v3.1 vector with CVSS:3.1 prefix");
+
+    assert_eq!(cvss.vector_string, vector);
+    assert_eq!(cvss.attack_vector, Some(cvss::v3::AttackVector::Network));
+}
+
+#[test]
+fn test_v3_missing_prefix() {
+    let vector = "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v3_1_invalid_lowercase_prefix() {
+    let vector = "cvss:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v3_1_invalid_mixed_case_prefix() {
+    let vector = "CvSs:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v3_invalid_prefix_version() {
+    let vector = "CVSS:3.2/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v3_invalid_malformed_prefix_version() {
+    let vector = "CVSS:3/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v3_parser_fails_on_v_2_0_vector() {
+    let vector = "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v3_invalid_malformed_vector() {
+    let vector = "THIS:JUSTISNTACVSSVECTOR";
+    let result = cvss::v3::CvssV3::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedVectorString)
+    ));
+}

--- a/tests/vector_validation_tests/v4_tests.rs
+++ b/tests/vector_validation_tests/v4_tests.rs
@@ -1,0 +1,89 @@
+use cvss_rs as cvss;
+use std::str::FromStr;
+
+#[test]
+fn test_v4_0_valid_prefix() {
+    let vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let cvss = cvss::v4_0::CvssV4::from_str(vector)
+        .expect("should parse valid v4.0 vector with CVSS:4.0 prefix");
+
+    assert_eq!(cvss.vector_string, vector);
+    assert_eq!(cvss.attack_vector, Some(cvss::v4_0::AttackVector::Network));
+}
+
+#[test]
+fn test_v4_0_missing_prefix() {
+    let vector = "AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_invalid_lowercase_prefix() {
+    let vector = "cvss:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_invalid_mixed_case_prefix() {
+    let vector = "CvSs:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixLabel { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_invalid_prefix_version() {
+    let vector = "CVSS:4.9/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_invalid_malformed_prefix_version() {
+    let vector = "CVSS:4/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_parser_fails_on_v_3_1_vector() {
+    let vector = "CVSS:3.1/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::InvalidPrefixVersion { .. })
+    ));
+}
+
+#[test]
+fn test_v4_0_invalid_malformed_vector() {
+    let vector = "THIS:JUSTISNTACVSSVECTOR";
+    let result = cvss::v4_0::CvssV4::from_str(vector);
+
+    assert!(matches!(
+        result,
+        Err(cvss::ParseError::MalformedVectorString)
+    ));
+}


### PR DESCRIPTION
This PR:
* adds utils/prefix.rs with shared functions to parse and validate CVSS vector string prefixes
* moves v2,v3,v4 parsing to use these shared functions
* in doing so, this tightens prefix validation: all prefixes are now required to start with "CVSS" (uppercase), followed by a known cvss version (CVSS v2 still has the prefix optional, but if it is present, it is validated)
* adds extensive testing to utils/prefix.rs and to the user-facing API

What I would like to discuss / breaking changes:
* On the csaf-rs side, we appreciate specific errors to allow for exact / helpful validation results for users. Because of this, I've added two new errors `MalformedVectorString` (the input does not contain any `/` seperators), `MalformedPrefixVersion` (the prefix version did not follow the "digit dot digit" format) and renamed the existing errors from `InvalidPrefix` -> `InvalidPrefixLabel` and `InvalidVersion` -> `InvalidPrefixVersion` to be more specific. This is a breaking change to all API consumers. So far, I have not added any backwards compatibility. Is this change towards more specific errors something you want in your library? If so, lets discuss if backwards compatibility / deprecation attributes / ... are required at the current stage / maturity of the library.

This PR resolves #22, and relates to #29, as the newly introduced errors will also need to be moved to thiserror if that PR is accepted.
