### PR TITLE
feat: cvss v2 rejects unknown metrics

### DIFF
--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -714,8 +714,7 @@ impl FromStr for CvssV2 {
                         })?);
                 }
                 _ => {
-                    // Silently ignore unknown metrics to be lenient with parsing
-                    // This allows us to parse vectors even if they have metrics we don't recognize
+                    return Err(ParseError::UnknownMetric { metric: key });
                 }
             }
         }

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -23,14 +23,10 @@ fn test_v2_0_minimal() {
 
 #[test]
 fn test_v2_0_unknown_metric_should_error() {
-    // Test that unknown metrics are rejected, not silently ignored
     let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/XX:H";
-    let result = CvssV2::from_str(vector);
 
-    assert!(result.is_err(), "Should reject unknown metric XX");
-    if let Err(cvss::ParseError::UnknownMetric { metric }) = result {
-        assert_eq!(metric, "XX");
-    } else {
-        panic!("Expected UnknownMetric error");
-    }
+    assert!(matches!(
+        CvssV2::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
 }

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -30,3 +30,13 @@ fn test_v2_0_unknown_metric_should_error() {
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
+
+#[test]
+fn test_v2_0_multiple_unknown_metric_should_error_first() {
+    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/XX:H/YY:H";
+
+    assert!(matches!(
+        CvssV2::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
+}

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -1,4 +1,6 @@
 use cvss_rs as cvss;
+use cvss_rs::v2_0::CvssV2;
+use std::str::FromStr;
 
 #[test]
 fn test_v2_0_example() {
@@ -17,4 +19,18 @@ fn test_v2_0_minimal() {
 
     assert_eq!(cvss.version(), cvss::Version::V2);
     assert_eq!(cvss.base_score(), 7.5);
+}
+
+#[test]
+fn test_v2_0_unknown_metric_should_error() {
+    // Test that unknown metrics are rejected, not silently ignored
+    let vector = "AV:N/AC:L/Au:N/C:C/I:C/A:C/XX:H";
+    let result = CvssV2::from_str(vector);
+
+    assert!(result.is_err(), "Should reject unknown metric XX");
+    if let Err(cvss::ParseError::UnknownMetric { metric }) = result {
+        assert_eq!(metric, "XX");
+    } else {
+        panic!("Expected UnknownMetric error");
+    }
 }

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -92,3 +92,13 @@ fn test_v3_1_unknown_metric_should_error() {
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
+
+#[test]
+fn test_v3_1_multiple_unknown_metric_should_error_first() {
+    let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/XX:H/YY:H";
+
+    assert!(matches!(
+        CvssV3::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
+}

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -82,3 +82,18 @@ fn test_v3_environmental() {
     assert_eq!(cvss.base_score(), 9.6);
     assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
 }
+
+#[test]
+fn test_v3_1_unknown_metric_should_error() {
+    // Test that unknown metrics are rejected, not silently ignored
+    let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/XX:H";
+    let result = CvssV3::from_str(vector);
+
+    assert!(result.is_err(), "Should reject unknown metric XX");
+    match result {
+        Err(cvss::ParseError::UnknownMetric { metric }) => {
+            assert_eq!(metric, "XX");
+        }
+        _ => panic!("Expected UnknownMetric error"),
+    }
+}

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -85,15 +85,10 @@ fn test_v3_environmental() {
 
 #[test]
 fn test_v3_1_unknown_metric_should_error() {
-    // Test that unknown metrics are rejected, not silently ignored
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/XX:H";
-    let result = CvssV3::from_str(vector);
 
-    assert!(result.is_err(), "Should reject unknown metric XX");
-    match result {
-        Err(cvss::ParseError::UnknownMetric { metric }) => {
-            assert_eq!(metric, "XX");
-        }
-        _ => panic!("Expected UnknownMetric error"),
-    }
+    assert!(matches!(
+        CvssV3::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
 }

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -113,3 +113,13 @@ fn test_v4_0_unknown_metric_should_error() {
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
+
+#[test]
+fn test_v4_0_multiple_unknown_metric_should_error_first() {
+    let vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/XX:H/YY:H";
+
+    assert!(matches!(
+        CvssV4::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
+}

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -106,15 +106,10 @@ fn test_v4_0_provider_urgency_values() {
 
 #[test]
 fn test_v4_0_unknown_metric_should_error() {
-    // Test that unknown metrics are rejected, not silently ignored
     let vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/XX:H";
-    let result = CvssV4::from_str(vector);
 
-    assert!(result.is_err(), "Should reject unknown metric XX");
-    match result {
-        Err(cvss::ParseError::UnknownMetric { metric }) => {
-            assert_eq!(metric, "XX");
-        }
-        _ => panic!("Expected UnknownMetric error"),
-    }
+    assert!(matches!(
+        CvssV4::from_str(vector),
+        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+    ));
 }

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -103,3 +103,18 @@ fn test_v4_0_provider_urgency_values() {
         CvssV4::from_str(&vector).unwrap_or_else(|e| panic!("Should parse U:{urgency}: {e}"));
     }
 }
+
+#[test]
+fn test_v4_0_unknown_metric_should_error() {
+    // Test that unknown metrics are rejected, not silently ignored
+    let vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/XX:H";
+    let result = CvssV4::from_str(vector);
+
+    assert!(result.is_err(), "Should reject unknown metric XX");
+    match result {
+        Err(cvss::ParseError::UnknownMetric { metric }) => {
+            assert_eq!(metric, "XX");
+        }
+        _ => panic!("Expected UnknownMetric error"),
+    }
+}


### PR DESCRIPTION
This PR:
- makes the CVSS v2 parser reject unknown metrics, like the v3 / v4 parsers do
- adds a test case each to pin this behaviour

Resolves #20 