### PR TITLE
fix: cvss v2 Display includes temp and env metrics

### DIFF
--- a/src/utils/format_vector.rs
+++ b/src/utils/format_vector.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+/// Writes a CVSS metric from an optional reference
+///
+/// This function writes a metric to the formatter with the pattern `/KEY:VALUE`.
+/// If the value is None, nothing is written.
+///
+/// # Arguments
+/// * `f` - formatter
+/// * `name` - metric name (e.g., "AV")
+/// * `value` - optional metric value
+pub fn write_metric<T: fmt::Display>(
+    f: &mut fmt::Formatter<'_>,
+    key: &str,
+    value: Option<&T>,
+) -> fmt::Result {
+    if let Some(val) = value {
+        write!(f, "/{}:{}", key, val)?;
+    }
+    Ok(())
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 //! Utility modules for CVSS parsing and validation.
 
+pub(crate) mod format_vector;
 pub(crate) mod parse_metrics;
 pub(crate) mod prefix;

--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -639,9 +639,11 @@ impl FromStr for CvssV2 {
 impl fmt::Display for CvssV2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // CVSS v2 typically doesn't include version prefix, but we'll include it for consistency
-        write!(f, "AV:")?;
+        write!(f, "CVSS:2.0")?;
+
+        // Base metrics
         if let Some(av) = &self.access_vector {
-            write!(f, "{}", av)?;
+            write!(f, "/AV:{}", av)?;
         }
         if let Some(ac) = &self.access_complexity {
             write!(f, "/AC:{}", ac)?;
@@ -657,6 +659,34 @@ impl fmt::Display for CvssV2 {
         }
         if let Some(a) = &self.availability_impact {
             write!(f, "/A:{}", a)?;
+        }
+
+        // Temporal metrics
+        if let Some(e) = &self.exploitability {
+            write!(f, "/E:{}", e)?;
+        }
+        if let Some(rl) = &self.remediation_level {
+            write!(f, "/RL:{}", rl)?;
+        }
+        if let Some(rc) = &self.report_confidence {
+            write!(f, "/RC:{}", rc)?;
+        }
+
+        // Environmental metrics
+        if let Some(cdp) = &self.collateral_damage_potential {
+            write!(f, "/CDP:{}", cdp)?;
+        }
+        if let Some(td) = &self.target_distribution {
+            write!(f, "/TD:{}", td)?;
+        }
+        if let Some(cr) = &self.confidentiality_requirement {
+            write!(f, "/CR:{}", cr)?;
+        }
+        if let Some(ir) = &self.integrity_requirement {
+            write!(f, "/IR:{}", ir)?;
+        }
+        if let Some(ar) = &self.availability_requirement {
+            write!(f, "/AR:{}", ar)?;
         }
 
         Ok(())

--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -68,6 +68,10 @@ pub struct CvssV2 {
     /// The availability requirement metric (environmental).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub availability_requirement: Option<SecurityRequirement>,
+    /// Whether the vector string had the CVSS:2.0/ prefix during parsing.
+    /// This is part of the CVSS data, so it's skipped during serialization.
+    #[serde(skip)]
+    pub has_prefix: bool,
 }
 
 /// Represents the qualitative severity rating of a vulnerability.
@@ -582,6 +586,7 @@ impl FromStr for CvssV2 {
             confidentiality_requirement: None,
             integrity_requirement: None,
             availability_requirement: None,
+            has_prefix: version_opt.is_some(),
         };
 
         // Parse metrics
@@ -638,56 +643,53 @@ impl FromStr for CvssV2 {
 
 impl fmt::Display for CvssV2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // CVSS v2 typically doesn't include version prefix, but we'll include it for consistency
-        write!(f, "CVSS:2.0")?;
+        // write prefix if it was present in the original parsed vector
+        if self.has_prefix {
+            write!(f, "CVSS:2.0")?;
+        }
+
+        // if there is a prefix, the first metric needs a leading slash (CVSS:2.0 / AV:H)
+        // if there isn't a prefix, the first metric must not have a leading slash (AV:H)
+        let mut write_leading_slash = !self.has_prefix;
+
+        // closure to write metrics with/without a leading separator
+        let mut write_metric = |name: &str, value: Option<&dyn fmt::Display>| -> fmt::Result {
+            if let Some(val) = value {
+                if !write_leading_slash {
+                    write!(f, "/")?;
+                }
+                write!(f, "{}:{}", name, val)?;
+                write_leading_slash = false;
+            }
+            Ok(())
+        };
+
+        // helper macro to avoid the repetitive dyn casting required for the closure
+        macro_rules! write_metric {
+            ($name:expr, $field:expr) => {
+                write_metric($name, $field.as_ref().map(|v| v as &dyn fmt::Display))
+            };
+        }
 
         // Base metrics
-        if let Some(av) = &self.access_vector {
-            write!(f, "/AV:{}", av)?;
-        }
-        if let Some(ac) = &self.access_complexity {
-            write!(f, "/AC:{}", ac)?;
-        }
-        if let Some(au) = &self.authentication {
-            write!(f, "/Au:{}", au)?;
-        }
-        if let Some(c) = &self.confidentiality_impact {
-            write!(f, "/C:{}", c)?;
-        }
-        if let Some(i) = &self.integrity_impact {
-            write!(f, "/I:{}", i)?;
-        }
-        if let Some(a) = &self.availability_impact {
-            write!(f, "/A:{}", a)?;
-        }
+        write_metric!("AV", self.access_vector)?;
+        write_metric!("AC", self.access_complexity)?;
+        write_metric!("Au", self.authentication)?;
+        write_metric!("C", self.confidentiality_impact)?;
+        write_metric!("I", self.integrity_impact)?;
+        write_metric!("A", self.availability_impact)?;
 
         // Temporal metrics
-        if let Some(e) = &self.exploitability {
-            write!(f, "/E:{}", e)?;
-        }
-        if let Some(rl) = &self.remediation_level {
-            write!(f, "/RL:{}", rl)?;
-        }
-        if let Some(rc) = &self.report_confidence {
-            write!(f, "/RC:{}", rc)?;
-        }
+        write_metric!("E", self.exploitability)?;
+        write_metric!("RL", self.remediation_level)?;
+        write_metric!("RC", self.report_confidence)?;
 
         // Environmental metrics
-        if let Some(cdp) = &self.collateral_damage_potential {
-            write!(f, "/CDP:{}", cdp)?;
-        }
-        if let Some(td) = &self.target_distribution {
-            write!(f, "/TD:{}", td)?;
-        }
-        if let Some(cr) = &self.confidentiality_requirement {
-            write!(f, "/CR:{}", cr)?;
-        }
-        if let Some(ir) = &self.integrity_requirement {
-            write!(f, "/IR:{}", ir)?;
-        }
-        if let Some(ar) = &self.availability_requirement {
-            write!(f, "/AR:{}", ar)?;
-        }
+        write_metric!("CDP", self.collateral_damage_potential)?;
+        write_metric!("TD", self.target_distribution)?;
+        write_metric!("CR", self.confidentiality_requirement)?;
+        write_metric!("IR", self.integrity_requirement)?;
+        write_metric!("AR", self.availability_requirement)?;
 
         Ok(())
     }

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-use crate::utils::{parse_metrics::parse_metric, prefix};
+use crate::utils::{format_vector::write_metric, parse_metrics::parse_metric, prefix};
 use crate::{version::VersionV3, ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v3.0 or v3.1 score object.
@@ -728,76 +728,32 @@ impl fmt::Display for CvssV3 {
         write!(f, "CVSS:{}", version)?;
 
         // Base metrics
-        if let Some(av) = &self.attack_vector {
-            write!(f, "/AV:{}", av)?;
-        }
-        if let Some(ac) = &self.attack_complexity {
-            write!(f, "/AC:{}", ac)?;
-        }
-        if let Some(pr) = &self.privileges_required {
-            write!(f, "/PR:{}", pr)?;
-        }
-        if let Some(ui) = &self.user_interaction {
-            write!(f, "/UI:{}", ui)?;
-        }
-        if let Some(s) = &self.scope {
-            write!(f, "/S:{}", s)?;
-        }
-        if let Some(c) = &self.confidentiality_impact {
-            write!(f, "/C:{}", c)?;
-        }
-        if let Some(i) = &self.integrity_impact {
-            write!(f, "/I:{}", i)?;
-        }
-        if let Some(a) = &self.availability_impact {
-            write!(f, "/A:{}", a)?;
-        }
+        write_metric(f, "AV", self.attack_vector.as_ref())?;
+        write_metric(f, "AC", self.attack_complexity.as_ref())?;
+        write_metric(f, "PR", self.privileges_required.as_ref())?;
+        write_metric(f, "UI", self.user_interaction.as_ref())?;
+        write_metric(f, "S", self.scope.as_ref())?;
+        write_metric(f, "C", self.confidentiality_impact.as_ref())?;
+        write_metric(f, "I", self.integrity_impact.as_ref())?;
+        write_metric(f, "A", self.availability_impact.as_ref())?;
 
         // Temporal metrics
-        if let Some(e) = &self.exploit_code_maturity {
-            write!(f, "/E:{}", e)?;
-        }
-        if let Some(rl) = &self.remediation_level {
-            write!(f, "/RL:{}", rl)?;
-        }
-        if let Some(rc) = &self.report_confidence {
-            write!(f, "/RC:{}", rc)?;
-        }
+        write_metric(f, "E", self.exploit_code_maturity.as_ref())?;
+        write_metric(f, "RL", self.remediation_level.as_ref())?;
+        write_metric(f, "RC", self.report_confidence.as_ref())?;
 
         // Environmental metrics
-        if let Some(cr) = &self.confidentiality_requirement {
-            write!(f, "/CR:{}", cr)?;
-        }
-        if let Some(ir) = &self.integrity_requirement {
-            write!(f, "/IR:{}", ir)?;
-        }
-        if let Some(ar) = &self.availability_requirement {
-            write!(f, "/AR:{}", ar)?;
-        }
-        if let Some(mav) = &self.modified_attack_vector {
-            write!(f, "/MAV:{}", mav)?;
-        }
-        if let Some(mac) = &self.modified_attack_complexity {
-            write!(f, "/MAC:{}", mac)?;
-        }
-        if let Some(mpr) = &self.modified_privileges_required {
-            write!(f, "/MPR:{}", mpr)?;
-        }
-        if let Some(mui) = &self.modified_user_interaction {
-            write!(f, "/MUI:{}", mui)?;
-        }
-        if let Some(ms) = &self.modified_scope {
-            write!(f, "/MS:{}", ms)?;
-        }
-        if let Some(mc) = &self.modified_confidentiality_impact {
-            write!(f, "/MC:{}", mc)?;
-        }
-        if let Some(mi) = &self.modified_integrity_impact {
-            write!(f, "/MI:{}", mi)?;
-        }
-        if let Some(ma) = &self.modified_availability_impact {
-            write!(f, "/MA:{}", ma)?;
-        }
+        write_metric(f, "CR", self.confidentiality_requirement.as_ref())?;
+        write_metric(f, "IR", self.integrity_requirement.as_ref())?;
+        write_metric(f, "AR", self.availability_requirement.as_ref())?;
+        write_metric(f, "MAV", self.modified_attack_vector.as_ref())?;
+        write_metric(f, "MAC", self.modified_attack_complexity.as_ref())?;
+        write_metric(f, "MPR", self.modified_privileges_required.as_ref())?;
+        write_metric(f, "MUI", self.modified_user_interaction.as_ref())?;
+        write_metric(f, "MS", self.modified_scope.as_ref())?;
+        write_metric(f, "MC", self.modified_confidentiality_impact.as_ref())?;
+        write_metric(f, "MI", self.modified_integrity_impact.as_ref())?;
+        write_metric(f, "MA", self.modified_availability_impact.as_ref())?;
 
         Ok(())
     }

--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-use crate::utils::{parse_metrics::parse_metric, prefix};
+use crate::utils::{format_vector::write_metric, parse_metrics::parse_metric, prefix};
 use crate::{ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v4.0 score object.
@@ -718,108 +718,44 @@ impl fmt::Display for CvssV4 {
         write!(f, "CVSS:4.0")?;
 
         // Base metrics
-        if let Some(av) = &self.attack_vector {
-            write!(f, "/AV:{}", av)?;
-        }
-        if let Some(ac) = &self.attack_complexity {
-            write!(f, "/AC:{}", ac)?;
-        }
-        if let Some(at) = &self.attack_requirements {
-            write!(f, "/AT:{}", at)?;
-        }
-        if let Some(pr) = &self.privileges_required {
-            write!(f, "/PR:{}", pr)?;
-        }
-        if let Some(ui) = &self.user_interaction {
-            write!(f, "/UI:{}", ui)?;
-        }
-        if let Some(vc) = &self.vuln_confidentiality_impact {
-            write!(f, "/VC:{}", vc)?;
-        }
-        if let Some(vi) = &self.vuln_integrity_impact {
-            write!(f, "/VI:{}", vi)?;
-        }
-        if let Some(va) = &self.vuln_availability_impact {
-            write!(f, "/VA:{}", va)?;
-        }
-        if let Some(sc) = &self.sub_confidentiality_impact {
-            write!(f, "/SC:{}", sc)?;
-        }
-        if let Some(si) = &self.sub_integrity_impact {
-            write!(f, "/SI:{}", si)?;
-        }
-        if let Some(sa) = &self.sub_availability_impact {
-            write!(f, "/SA:{}", sa)?;
-        }
+        write_metric(f, "AV", self.attack_vector.as_ref())?;
+        write_metric(f, "AC", self.attack_complexity.as_ref())?;
+        write_metric(f, "AT", self.attack_requirements.as_ref())?;
+        write_metric(f, "PR", self.privileges_required.as_ref())?;
+        write_metric(f, "UI", self.user_interaction.as_ref())?;
+        write_metric(f, "VC", self.vuln_confidentiality_impact.as_ref())?;
+        write_metric(f, "VI", self.vuln_integrity_impact.as_ref())?;
+        write_metric(f, "VA", self.vuln_availability_impact.as_ref())?;
+        write_metric(f, "SC", self.sub_confidentiality_impact.as_ref())?;
+        write_metric(f, "SI", self.sub_integrity_impact.as_ref())?;
+        write_metric(f, "SA", self.sub_availability_impact.as_ref())?;
 
         // Threat metrics
-        if let Some(e) = &self.exploit_maturity {
-            write!(f, "/E:{}", e)?;
-        }
+        write_metric(f, "E", self.exploit_maturity.as_ref())?;
 
         // Environmental metrics
-        if let Some(cr) = &self.confidentiality_requirement {
-            write!(f, "/CR:{}", cr)?;
-        }
-        if let Some(ir) = &self.integrity_requirement {
-            write!(f, "/IR:{}", ir)?;
-        }
-        if let Some(ar) = &self.availability_requirement {
-            write!(f, "/AR:{}", ar)?;
-        }
-        if let Some(mav) = &self.modified_attack_vector {
-            write!(f, "/MAV:{}", mav)?;
-        }
-        if let Some(mac) = &self.modified_attack_complexity {
-            write!(f, "/MAC:{}", mac)?;
-        }
-        if let Some(mat) = &self.modified_attack_requirements {
-            write!(f, "/MAT:{}", mat)?;
-        }
-        if let Some(mpr) = &self.modified_privileges_required {
-            write!(f, "/MPR:{}", mpr)?;
-        }
-        if let Some(mui) = &self.modified_user_interaction {
-            write!(f, "/MUI:{}", mui)?;
-        }
-        if let Some(mvc) = &self.modified_vuln_confidentiality_impact {
-            write!(f, "/MVC:{}", mvc)?;
-        }
-        if let Some(mvi) = &self.modified_vuln_integrity_impact {
-            write!(f, "/MVI:{}", mvi)?;
-        }
-        if let Some(mva) = &self.modified_vuln_availability_impact {
-            write!(f, "/MVA:{}", mva)?;
-        }
-        if let Some(msc) = &self.modified_sub_confidentiality_impact {
-            write!(f, "/MSC:{}", msc)?;
-        }
-        if let Some(msi) = &self.modified_sub_integrity_impact {
-            write!(f, "/MSI:{}", msi)?;
-        }
-        if let Some(msa) = &self.modified_sub_availability_impact {
-            write!(f, "/MSA:{}", msa)?;
-        }
+        write_metric(f, "CR", self.confidentiality_requirement.as_ref())?;
+        write_metric(f, "IR", self.integrity_requirement.as_ref())?;
+        write_metric(f, "AR", self.availability_requirement.as_ref())?;
+        write_metric(f, "MAV", self.modified_attack_vector.as_ref())?;
+        write_metric(f, "MAC", self.modified_attack_complexity.as_ref())?;
+        write_metric(f, "MAT", self.modified_attack_requirements.as_ref())?;
+        write_metric(f, "MPR", self.modified_privileges_required.as_ref())?;
+        write_metric(f, "MUI", self.modified_user_interaction.as_ref())?;
+        write_metric(f, "MVC", self.modified_vuln_confidentiality_impact.as_ref())?;
+        write_metric(f, "MVI", self.modified_vuln_integrity_impact.as_ref())?;
+        write_metric(f, "MVA", self.modified_vuln_availability_impact.as_ref())?;
+        write_metric(f, "MSC", self.modified_sub_confidentiality_impact.as_ref())?;
+        write_metric(f, "MSI", self.modified_sub_integrity_impact.as_ref())?;
+        write_metric(f, "MSA", self.modified_sub_availability_impact.as_ref())?;
 
         // Supplemental metrics
-        if let Some(s) = &self.safety {
-            write!(f, "/S:{}", s)?;
-        }
-        if let Some(au) = &self.automatable {
-            write!(f, "/AU:{}", au)?;
-        }
-        if let Some(r) = &self.recovery {
-            write!(f, "/R:{}", r)?;
-        }
-        if let Some(v) = &self.value_density {
-            write!(f, "/V:{}", v)?;
-        }
-        if let Some(re) = &self.vulnerability_response_effort {
-            write!(f, "/RE:{}", re)?;
-        }
-        if let Some(u) = &self.provider_urgency {
-            write!(f, "/U:{}", u)?;
-        }
+        write_metric(f, "S", self.safety.as_ref())?;
+        write_metric(f, "AU", self.automatable.as_ref())?;
+        write_metric(f, "R", self.recovery.as_ref())?;
+        write_metric(f, "V", self.value_density.as_ref())?;
+        write_metric(f, "RE", self.vulnerability_response_effort.as_ref())?;
+        write_metric(f, "U", self.provider_urgency.as_ref())?;
 
         Ok(())
     }

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -66,3 +66,38 @@ fn test_v2_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
         result
     );
 }
+
+#[test]
+fn test_v2_0_display_round_trip() {
+    // Create a v2 vector with all metrics defined
+    let vector_str = "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:H/IR:H/AR:H";
+
+    // Parse the vector string
+    let o = cvss::v2_0::CvssV2::from_str(vector_str).expect("Failed to parse vector string");
+
+    // Convert to string using Display
+    let display_string = o.to_string();
+
+    // Parse the display string back
+    let r = cvss::v2_0::CvssV2::from_str(&display_string).expect("Failed to parse Display output");
+
+    // Verify all base metrics
+    assert_eq!(o.access_vector, r.access_vector);
+    assert_eq!(o.access_complexity, r.access_complexity);
+    assert_eq!(o.authentication, r.authentication);
+    assert_eq!(o.confidentiality_impact, r.confidentiality_impact);
+    assert_eq!(o.integrity_impact, r.integrity_impact);
+    assert_eq!(o.availability_impact, r.availability_impact);
+
+    // Verify all temporal metrics
+    assert_eq!(o.exploitability, r.exploitability);
+    assert_eq!(o.remediation_level, r.remediation_level);
+    assert_eq!(o.report_confidence, r.report_confidence);
+
+    // Verify all environmental metrics
+    assert_eq!(o.collateral_damage_potential, r.collateral_damage_potential);
+    assert_eq!(o.target_distribution, r.target_distribution);
+    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
+    assert_eq!(o.integrity_requirement, r.integrity_requirement);
+    assert_eq!(o.availability_requirement, r.availability_requirement);
+}

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -1,24 +1,23 @@
-use cvss_rs as cvss;
-use cvss_rs::{v2_0::CvssV2, ParseError};
+use cvss_rs::{v2_0::CvssV2, Cvss, ParseError, Severity, Version};
 use rstest::rstest;
 use std::str::FromStr;
 
 #[test]
 fn test_v2_0_example() {
     let input_json = include_str!("data/v2_0_example.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V2);
+    assert_eq!(cvss.version(), Version::V2);
     assert_eq!(cvss.base_score(), 7.5);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::High);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::High);
 }
 
 #[test]
 fn test_v2_0_minimal() {
     let input_json = include_str!("data/v2_0_minimal.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V2);
+    assert_eq!(cvss.version(), Version::V2);
     assert_eq!(cvss.base_score(), 7.5);
 }
 
@@ -28,7 +27,7 @@ fn test_v2_0_unknown_metric_should_error() {
 
     assert!(matches!(
         CvssV2::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 
@@ -38,7 +37,7 @@ fn test_v2_0_multiple_unknown_metric_should_error_first() {
 
     assert!(matches!(
         CvssV2::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 
@@ -67,37 +66,20 @@ fn test_v2_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
     );
 }
 
-#[test]
-fn test_v2_0_display_round_trip() {
-    // Create a v2 vector with all metrics defined
-    let vector_str = "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:H/IR:H/AR:H";
-
+#[rstest]
+#[case("CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:H/IR:H/AR:H")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/E:F/RL:OF/RC:C/CDP:H/TD:H/CR:H/IR:H/AR:H")]
+fn test_v2_0_display_round_trip(#[case] vector_str: &str) {
     // Parse the vector string
-    let o = cvss::v2_0::CvssV2::from_str(vector_str).expect("Failed to parse vector string");
+    let parsed = CvssV2::from_str(vector_str).expect("Failed to parse vector string");
 
     // Convert to string using Display
-    let display_string = o.to_string();
+    let parsed_str = parsed.to_string();
 
-    // Parse the display string back
-    let r = cvss::v2_0::CvssV2::from_str(&display_string).expect("Failed to parse Display output");
-
-    // Verify all base metrics
-    assert_eq!(o.access_vector, r.access_vector);
-    assert_eq!(o.access_complexity, r.access_complexity);
-    assert_eq!(o.authentication, r.authentication);
-    assert_eq!(o.confidentiality_impact, r.confidentiality_impact);
-    assert_eq!(o.integrity_impact, r.integrity_impact);
-    assert_eq!(o.availability_impact, r.availability_impact);
-
-    // Verify all temporal metrics
-    assert_eq!(o.exploitability, r.exploitability);
-    assert_eq!(o.remediation_level, r.remediation_level);
-    assert_eq!(o.report_confidence, r.report_confidence);
-
-    // Verify all environmental metrics
-    assert_eq!(o.collateral_damage_potential, r.collateral_damage_potential);
-    assert_eq!(o.target_distribution, r.target_distribution);
-    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
-    assert_eq!(o.integrity_requirement, r.integrity_requirement);
-    assert_eq!(o.availability_requirement, r.availability_requirement);
+    // Verify round-trip
+    assert_eq!(
+        parsed_str, vector_str,
+        "Round-trip failed for: {}",
+        vector_str
+    );
 }

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -1,6 +1,7 @@
-use cvss::v3::AttackVector;
-use cvss_rs as cvss;
-use cvss_rs::{v3::CvssV3, ParseError};
+use cvss_rs::{
+    v3::{AttackVector, CvssV3},
+    Cvss, ParseError, Severity, Version,
+};
 use rstest::rstest;
 use std::str::FromStr;
 
@@ -40,34 +41,34 @@ fn test_v3_1_rounding_examples() {
 #[test]
 fn test_v3_1_critical() {
     let input_json = include_str!("data/v3_1_critical.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V3_1);
+    assert_eq!(cvss.version(), Version::V3_1);
     assert_eq!(cvss.base_score(), 9.8);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Critical);
 }
 
 #[test]
 fn test_v3_0_critical() {
     let input_json = include_str!("data/v3_0_critical.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V3_0);
+    assert_eq!(cvss.version(), Version::V3_0);
     assert_eq!(cvss.base_score(), 9.8);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Critical);
 }
 
 #[test]
 fn test_v3_1_medium() {
     let input_json = include_str!("data/v3_1_medium.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V3_1);
+    assert_eq!(cvss.version(), Version::V3_1);
     assert_eq!(cvss.base_score(), 5.8);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Medium);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Medium);
 
     // Custom assertion for v3_1_medium
-    if let cvss::Cvss::V3_1(c) = cvss {
+    if let Cvss::V3_1(c) = cvss {
         assert_eq!(c.attack_vector, Some(AttackVector::Local));
     } else {
         panic!("Wrong enum variant");
@@ -77,11 +78,11 @@ fn test_v3_1_medium() {
 #[test]
 fn test_v3_environmental() {
     let input_json = include_str!("data/v3_environmental.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V3_1);
+    assert_eq!(cvss.version(), Version::V3_1);
     assert_eq!(cvss.base_score(), 9.6);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Critical);
 }
 
 #[test]
@@ -95,44 +96,11 @@ fn test_v3_1_display_round_trip() {
     // Convert to string using Display
     let display_string = o.to_string();
 
-    // Parse the display string back
-    let r = CvssV3::from_str(&display_string).expect("Failed to parse Display output");
-
-    // Verify all base metrics
-    assert_eq!(o.attack_vector, r.attack_vector);
-    assert_eq!(o.attack_complexity, r.attack_complexity);
-    assert_eq!(o.privileges_required, r.privileges_required);
-    assert_eq!(o.user_interaction, r.user_interaction);
-    assert_eq!(o.scope, r.scope);
-    assert_eq!(o.confidentiality_impact, r.confidentiality_impact);
-    assert_eq!(o.integrity_impact, r.integrity_impact);
-    assert_eq!(o.availability_impact, r.availability_impact);
-
-    // Verify all temporal metrics
-    assert_eq!(o.exploit_code_maturity, r.exploit_code_maturity);
-    assert_eq!(o.remediation_level, r.remediation_level);
-    assert_eq!(o.report_confidence, r.report_confidence);
-
-    // Verify all environmental metrics
-    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
-    assert_eq!(o.integrity_requirement, r.integrity_requirement);
-    assert_eq!(o.availability_requirement, r.availability_requirement);
-    assert_eq!(o.modified_attack_vector, r.modified_attack_vector);
-    assert_eq!(o.modified_attack_complexity, r.modified_attack_complexity);
+    // Verify round-trip
     assert_eq!(
-        o.modified_privileges_required,
-        r.modified_privileges_required
-    );
-    assert_eq!(o.modified_user_interaction, r.modified_user_interaction);
-    assert_eq!(o.modified_scope, r.modified_scope);
-    assert_eq!(
-        o.modified_confidentiality_impact,
-        r.modified_confidentiality_impact
-    );
-    assert_eq!(o.modified_integrity_impact, r.modified_integrity_impact);
-    assert_eq!(
-        o.modified_availability_impact,
-        r.modified_availability_impact
+        display_string, vector_string,
+        "Round-trip failed for: {}",
+        vector_string
     );
 }
 
@@ -142,7 +110,7 @@ fn test_v3_1_unknown_metric_should_error() {
 
     assert!(matches!(
         CvssV3::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 
@@ -152,7 +120,7 @@ fn test_v3_1_multiple_unknown_metric_should_error_first() {
 
     assert!(matches!(
         CvssV3::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -85,6 +85,58 @@ fn test_v3_environmental() {
 }
 
 #[test]
+fn test_v3_1_display_round_trip() {
+    // Create a v3.1 vector with all metrics defined
+    let vector_string = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:T/RC:C/CR:H/IR:H/AR:H/MAV:L/MAC:H/MPR:H/MUI:R/MS:C/MC:L/MI:L/MA:L";
+
+    // Parse the vector string
+    let o = CvssV3::from_str(vector_string).expect("Failed to parse vector string");
+
+    // Convert to string using Display
+    let display_string = o.to_string();
+
+    // Parse the display string back
+    let r = CvssV3::from_str(&display_string).expect("Failed to parse Display output");
+
+    // Verify all base metrics
+    assert_eq!(o.attack_vector, r.attack_vector);
+    assert_eq!(o.attack_complexity, r.attack_complexity);
+    assert_eq!(o.privileges_required, r.privileges_required);
+    assert_eq!(o.user_interaction, r.user_interaction);
+    assert_eq!(o.scope, r.scope);
+    assert_eq!(o.confidentiality_impact, r.confidentiality_impact);
+    assert_eq!(o.integrity_impact, r.integrity_impact);
+    assert_eq!(o.availability_impact, r.availability_impact);
+
+    // Verify all temporal metrics
+    assert_eq!(o.exploit_code_maturity, r.exploit_code_maturity);
+    assert_eq!(o.remediation_level, r.remediation_level);
+    assert_eq!(o.report_confidence, r.report_confidence);
+
+    // Verify all environmental metrics
+    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
+    assert_eq!(o.integrity_requirement, r.integrity_requirement);
+    assert_eq!(o.availability_requirement, r.availability_requirement);
+    assert_eq!(o.modified_attack_vector, r.modified_attack_vector);
+    assert_eq!(o.modified_attack_complexity, r.modified_attack_complexity);
+    assert_eq!(
+        o.modified_privileges_required,
+        r.modified_privileges_required
+    );
+    assert_eq!(o.modified_user_interaction, r.modified_user_interaction);
+    assert_eq!(o.modified_scope, r.modified_scope);
+    assert_eq!(
+        o.modified_confidentiality_impact,
+        r.modified_confidentiality_impact
+    );
+    assert_eq!(o.modified_integrity_impact, r.modified_integrity_impact);
+    assert_eq!(
+        o.modified_availability_impact,
+        r.modified_availability_impact
+    );
+}
+
+#[test]
 fn test_v3_1_unknown_metric_should_error() {
     let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/XX:H";
 

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -1,5 +1,4 @@
-use cvss_rs as cvss;
-use cvss_rs::{v4_0::CvssV4, ParseError};
+use cvss_rs::{v4_0::CvssV4, Cvss, ParseError, Severity, Version};
 use rstest::rstest;
 use std::str::FromStr;
 
@@ -37,31 +36,31 @@ fn test_v4_0_exploit_maturity_notdefined() {
 #[test]
 fn test_v4_0_example() {
     let input_json = include_str!("data/v4_0_example.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V4);
+    assert_eq!(cvss.version(), Version::V4);
     assert_eq!(cvss.base_score(), 9.3);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Critical);
 }
 
 #[test]
 fn test_v4_0_cve_example() {
     let input_json = include_str!("data/v4_0_cve_example.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V4);
+    assert_eq!(cvss.version(), Version::V4);
     assert_eq!(cvss.base_score(), 5.9);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Medium);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Medium);
 }
 
 #[test]
 fn test_v4_0_minimal() {
     let input_json = include_str!("data/v4_0_minimal.json");
-    let cvss: cvss::Cvss = serde_json::from_str(input_json).unwrap();
+    let cvss: Cvss = serde_json::from_str(input_json).unwrap();
 
-    assert_eq!(cvss.version(), cvss::Version::V4);
+    assert_eq!(cvss.version(), Version::V4);
     assert_eq!(cvss.base_score(), 9.9);
-    assert_eq!(cvss.base_severity().unwrap(), cvss::Severity::Critical);
+    assert_eq!(cvss.base_severity().unwrap(), Severity::Critical);
 }
 
 #[test]
@@ -111,7 +110,7 @@ fn test_v4_0_unknown_metric_should_error() {
 
     assert!(matches!(
         CvssV4::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 
@@ -121,7 +120,7 @@ fn test_v4_0_multiple_unknown_metric_should_error_first() {
 
     assert!(matches!(
         CvssV4::from_str(vector),
-        Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
+        Err(ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
 }
 
@@ -168,73 +167,10 @@ fn test_v4_0_display_round_trip() {
     // Convert to string using Display
     let display_string = o.to_string();
 
-    // Parse the display string back
-    let r = CvssV4::from_str(&display_string).expect("Failed to parse Display output");
-
-    // Verify all base metrics
-    assert_eq!(o.attack_vector, r.attack_vector);
-    assert_eq!(o.attack_complexity, r.attack_complexity);
-    assert_eq!(o.attack_requirements, r.attack_requirements);
-    assert_eq!(o.privileges_required, r.privileges_required);
-    assert_eq!(o.user_interaction, r.user_interaction);
-    assert_eq!(o.vuln_confidentiality_impact, r.vuln_confidentiality_impact);
-    assert_eq!(o.vuln_integrity_impact, r.vuln_integrity_impact);
-    assert_eq!(o.vuln_availability_impact, r.vuln_availability_impact);
-    assert_eq!(o.sub_confidentiality_impact, r.sub_confidentiality_impact);
-    assert_eq!(o.sub_integrity_impact, r.sub_integrity_impact);
-    assert_eq!(o.sub_availability_impact, r.sub_availability_impact);
-
-    // Verify threat metrics
-    assert_eq!(o.exploit_maturity, r.exploit_maturity);
-
-    // Verify environmental metrics
-    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
-    assert_eq!(o.integrity_requirement, r.integrity_requirement);
-    assert_eq!(o.availability_requirement, r.availability_requirement);
-    assert_eq!(o.modified_attack_vector, r.modified_attack_vector);
-    assert_eq!(o.modified_attack_complexity, r.modified_attack_complexity);
+    // Verify round-trip
     assert_eq!(
-        o.modified_attack_requirements,
-        r.modified_attack_requirements
+        display_string, vector_string,
+        "Round-trip failed for: {}",
+        vector_string
     );
-    assert_eq!(
-        o.modified_privileges_required,
-        r.modified_privileges_required
-    );
-    assert_eq!(o.modified_user_interaction, r.modified_user_interaction);
-    assert_eq!(
-        o.modified_vuln_confidentiality_impact,
-        r.modified_vuln_confidentiality_impact
-    );
-    assert_eq!(
-        o.modified_vuln_integrity_impact,
-        r.modified_vuln_integrity_impact
-    );
-    assert_eq!(
-        o.modified_vuln_availability_impact,
-        r.modified_vuln_availability_impact
-    );
-    assert_eq!(
-        o.modified_sub_confidentiality_impact,
-        r.modified_sub_confidentiality_impact
-    );
-    assert_eq!(
-        o.modified_sub_integrity_impact,
-        r.modified_sub_integrity_impact
-    );
-    assert_eq!(
-        o.modified_sub_availability_impact,
-        r.modified_sub_availability_impact
-    );
-
-    // Verify supplemental metrics
-    assert_eq!(o.safety, r.safety);
-    assert_eq!(o.automatable, r.automatable);
-    assert_eq!(o.recovery, r.recovery);
-    assert_eq!(o.value_density, r.value_density);
-    assert_eq!(
-        o.vulnerability_response_effort,
-        r.vulnerability_response_effort
-    );
-    assert_eq!(o.provider_urgency, r.provider_urgency);
 }

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -156,3 +156,85 @@ fn test_v4_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
         result
     );
 }
+
+#[test]
+fn test_v4_0_display_round_trip() {
+    // Create a v4.0 vector with all metrics defined
+    let vector_string = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:L/SI:L/SA:L/E:A/CR:H/IR:H/AR:H/MAV:L/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:L/MSA:L/S:P/AU:Y/R:A/V:D/RE:M/U:Green";
+
+    // Parse the vector string
+    let o = CvssV4::from_str(vector_string).expect("Failed to parse vector string");
+
+    // Convert to string using Display
+    let display_string = o.to_string();
+
+    // Parse the display string back
+    let r = CvssV4::from_str(&display_string).expect("Failed to parse Display output");
+
+    // Verify all base metrics
+    assert_eq!(o.attack_vector, r.attack_vector);
+    assert_eq!(o.attack_complexity, r.attack_complexity);
+    assert_eq!(o.attack_requirements, r.attack_requirements);
+    assert_eq!(o.privileges_required, r.privileges_required);
+    assert_eq!(o.user_interaction, r.user_interaction);
+    assert_eq!(o.vuln_confidentiality_impact, r.vuln_confidentiality_impact);
+    assert_eq!(o.vuln_integrity_impact, r.vuln_integrity_impact);
+    assert_eq!(o.vuln_availability_impact, r.vuln_availability_impact);
+    assert_eq!(o.sub_confidentiality_impact, r.sub_confidentiality_impact);
+    assert_eq!(o.sub_integrity_impact, r.sub_integrity_impact);
+    assert_eq!(o.sub_availability_impact, r.sub_availability_impact);
+
+    // Verify threat metrics
+    assert_eq!(o.exploit_maturity, r.exploit_maturity);
+
+    // Verify environmental metrics
+    assert_eq!(o.confidentiality_requirement, r.confidentiality_requirement);
+    assert_eq!(o.integrity_requirement, r.integrity_requirement);
+    assert_eq!(o.availability_requirement, r.availability_requirement);
+    assert_eq!(o.modified_attack_vector, r.modified_attack_vector);
+    assert_eq!(o.modified_attack_complexity, r.modified_attack_complexity);
+    assert_eq!(
+        o.modified_attack_requirements,
+        r.modified_attack_requirements
+    );
+    assert_eq!(
+        o.modified_privileges_required,
+        r.modified_privileges_required
+    );
+    assert_eq!(o.modified_user_interaction, r.modified_user_interaction);
+    assert_eq!(
+        o.modified_vuln_confidentiality_impact,
+        r.modified_vuln_confidentiality_impact
+    );
+    assert_eq!(
+        o.modified_vuln_integrity_impact,
+        r.modified_vuln_integrity_impact
+    );
+    assert_eq!(
+        o.modified_vuln_availability_impact,
+        r.modified_vuln_availability_impact
+    );
+    assert_eq!(
+        o.modified_sub_confidentiality_impact,
+        r.modified_sub_confidentiality_impact
+    );
+    assert_eq!(
+        o.modified_sub_integrity_impact,
+        r.modified_sub_integrity_impact
+    );
+    assert_eq!(
+        o.modified_sub_availability_impact,
+        r.modified_sub_availability_impact
+    );
+
+    // Verify supplemental metrics
+    assert_eq!(o.safety, r.safety);
+    assert_eq!(o.automatable, r.automatable);
+    assert_eq!(o.recovery, r.recovery);
+    assert_eq!(o.value_density, r.value_density);
+    assert_eq!(
+        o.vulnerability_response_effort,
+        r.vulnerability_response_effort
+    );
+    assert_eq!(o.provider_urgency, r.provider_urgency);
+}


### PR DESCRIPTION
This PR:
* adds the temp and env metrics to the cvss v2 display function, which so far only printed base metrics
* adds round-trip tests for CVSS v2,v3,v4 to assert that the display function does not make any unintended changes to the vectors

What I would like to discuss / breaking changes:
* This is a breaking change to all consumers that rely on the cvss v2 Display function **not** printing the temp / env metrics. I would argue this change is more correct, and the breaking change is justified. Do you know if there are consumers that depend on this, i.e. if we should provide a "print only base metrics" function for these consumers / also for v3/v4?
* In line with the preexisting comment on the v2 Display function, the Display function now prepends "CVSS:2.0/" to the output. This is also a breaking change, and does introduce some roundtrip wierdness for v2 vectors that were provided without the optional prefix. I can see multiple ways to handle this, including setting a flag if the vector was provided with/without the prefix, which would allow for round-trips with and without the prefix being present.