### PR TITLE
feat: duplicate metrics fail parsers

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 //! Utility modules for CVSS parsing and validation.
 
+pub(crate) mod parse_metrics;
 pub(crate) mod prefix;

--- a/src/utils/parse_metrics.rs
+++ b/src/utils/parse_metrics.rs
@@ -1,0 +1,34 @@
+use crate::ParseError;
+use std::str::FromStr;
+
+/// Generic helper function for parsing and setting metrics. It checks for duplicate metrics
+/// and invalid metric values.
+///
+/// # Arguments
+///
+/// * `field` - mutable reference to an Option field to be populated
+/// * `value` - input value
+/// * `key` - metric key used for error reporting
+///
+/// # Returns
+///
+/// * `Ok(())` if the metric was successfully parsed and set
+/// * `Err(ParseError)` if the metric is a duplicate or if parsing fails
+pub(crate) fn parse_metric<T: FromStr>(
+    field: &mut Option<T>,
+    value: &str,
+    key: &str,
+) -> Result<(), ParseError> {
+    // check if the metric is already populated, i.e. if there is a duplicate metric
+    if field.is_some() {
+        return Err(ParseError::DuplicateMetric {
+            metric: key.to_string(),
+        });
+    }
+    // check metric value validity -> either set value or throw invalid value error
+    *field = Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
+        metric: key.to_string(),
+        value: value.to_string(),
+    })?);
+    Ok(())
+}

--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -1,13 +1,13 @@
 //! Represents the CVSS v2.0 specification.
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-use crate::utils::prefix;
-use crate::Version;
-use crate::{ParseError, Severity as UnifiedSeverity};
+use crate::utils::{parse_metrics::parse_metric, prefix};
+use crate::{ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v2.0 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -612,109 +612,23 @@ impl FromStr for CvssV2 {
             }
 
             match key.as_str() {
-                "AV" => {
-                    cvss.access_vector =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AC" => {
-                    cvss.access_complexity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AU" => {
-                    cvss.authentication =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "C" => {
-                    cvss.confidentiality_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "I" => {
-                    cvss.integrity_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "A" => {
-                    cvss.availability_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "AV" => parse_metric(&mut cvss.access_vector, &value, &key)?,
+                "AC" => parse_metric(&mut cvss.access_complexity, &value, &key)?,
+                "AU" => parse_metric(&mut cvss.authentication, &value, &key)?,
+                "C" => parse_metric(&mut cvss.confidentiality_impact, &value, &key)?,
+                "I" => parse_metric(&mut cvss.integrity_impact, &value, &key)?,
+                "A" => parse_metric(&mut cvss.availability_impact, &value, &key)?,
                 // Temporal metrics
-                "E" => {
-                    cvss.exploitability =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "RL" => {
-                    cvss.remediation_level =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "RC" => {
-                    cvss.report_confidence =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "E" => parse_metric(&mut cvss.exploitability, &value, &key)?,
+                "RL" => parse_metric(&mut cvss.remediation_level, &value, &key)?,
+                "RC" => parse_metric(&mut cvss.report_confidence, &value, &key)?,
                 // Environmental metrics
-                "CDP" => {
-                    cvss.collateral_damage_potential =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "TD" => {
-                    cvss.target_distribution =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "CR" => {
-                    cvss.confidentiality_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "IR" => {
-                    cvss.integrity_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AR" => {
-                    cvss.availability_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                _ => {
-                    return Err(ParseError::UnknownMetric { metric: key });
-                }
+                "CDP" => parse_metric(&mut cvss.collateral_damage_potential, &value, &key)?,
+                "TD" => parse_metric(&mut cvss.target_distribution, &value, &key)?,
+                "CR" => parse_metric(&mut cvss.confidentiality_requirement, &value, &key)?,
+                "IR" => parse_metric(&mut cvss.integrity_requirement, &value, &key)?,
+                "AR" => parse_metric(&mut cvss.availability_requirement, &value, &key)?,
+                _ => return Err(ParseError::UnknownMetric { metric: key }),
             }
         }
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -1,11 +1,13 @@
 //! Represents the CVSS v3.0 and v3.1 specifications.
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-use crate::{utils::prefix, version::VersionV3, ParseError, Severity as UnifiedSeverity, Version};
+use crate::utils::{parse_metrics::parse_metric, prefix};
+use crate::{version::VersionV3, ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v3.0 or v3.1 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -679,162 +681,31 @@ impl FromStr for CvssV3 {
 
             match key.as_str() {
                 // Base metrics
-                "AV" => {
-                    cvss.attack_vector =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AC" => {
-                    cvss.attack_complexity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "PR" => {
-                    cvss.privileges_required =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "UI" => {
-                    cvss.user_interaction =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "S" => {
-                    cvss.scope =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "C" => {
-                    cvss.confidentiality_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "I" => {
-                    cvss.integrity_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "A" => {
-                    cvss.availability_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "AV" => parse_metric(&mut cvss.attack_vector, &value, &key)?,
+                "AC" => parse_metric(&mut cvss.attack_complexity, &value, &key)?,
+                "PR" => parse_metric(&mut cvss.privileges_required, &value, &key)?,
+                "UI" => parse_metric(&mut cvss.user_interaction, &value, &key)?,
+                "S" => parse_metric(&mut cvss.scope, &value, &key)?,
+                "C" => parse_metric(&mut cvss.confidentiality_impact, &value, &key)?,
+                "I" => parse_metric(&mut cvss.integrity_impact, &value, &key)?,
+                "A" => parse_metric(&mut cvss.availability_impact, &value, &key)?,
                 // Temporal metrics
-                "E" => {
-                    cvss.exploit_code_maturity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "RL" => {
-                    cvss.remediation_level =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "RC" => {
-                    cvss.report_confidence =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "E" => parse_metric(&mut cvss.exploit_code_maturity, &value, &key)?,
+                "RL" => parse_metric(&mut cvss.remediation_level, &value, &key)?,
+                "RC" => parse_metric(&mut cvss.report_confidence, &value, &key)?,
                 // Environmental metrics
-                "CR" => {
-                    cvss.confidentiality_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "IR" => {
-                    cvss.integrity_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AR" => {
-                    cvss.availability_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MAV" => {
-                    cvss.modified_attack_vector =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MAC" => {
-                    cvss.modified_attack_complexity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MPR" => {
-                    cvss.modified_privileges_required =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MUI" => {
-                    cvss.modified_user_interaction =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MS" => {
-                    cvss.modified_scope =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MC" => {
-                    cvss.modified_confidentiality_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MI" => {
-                    cvss.modified_integrity_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MA" => {
-                    cvss.modified_availability_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "CR" => parse_metric(&mut cvss.confidentiality_requirement, &value, &key)?,
+                "IR" => parse_metric(&mut cvss.integrity_requirement, &value, &key)?,
+                "AR" => parse_metric(&mut cvss.availability_requirement, &value, &key)?,
+                // Modified metrics
+                "MAV" => parse_metric(&mut cvss.modified_attack_vector, &value, &key)?,
+                "MAC" => parse_metric(&mut cvss.modified_attack_complexity, &value, &key)?,
+                "MPR" => parse_metric(&mut cvss.modified_privileges_required, &value, &key)?,
+                "MUI" => parse_metric(&mut cvss.modified_user_interaction, &value, &key)?,
+                "MS" => parse_metric(&mut cvss.modified_scope, &value, &key)?,
+                "MC" => parse_metric(&mut cvss.modified_confidentiality_impact, &value, &key)?,
+                "MI" => parse_metric(&mut cvss.modified_integrity_impact, &value, &key)?,
+                "MA" => parse_metric(&mut cvss.modified_availability_impact, &value, &key)?,
                 _ => {
                     return Err(ParseError::UnknownMetric { metric: key });
                 }

--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -6,14 +6,14 @@ mod scoring;
 
 pub use score::Nomenclature;
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
-use crate::utils::prefix;
-use crate::Version;
-use crate::{ParseError, Severity as UnifiedSeverity};
+use crate::utils::{parse_metrics::parse_metric, prefix};
+use crate::{ParseError, Severity as UnifiedSeverity, Version};
 
 /// Represents a CVSS v4.0 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -665,255 +665,44 @@ impl FromStr for CvssV4 {
 
             match key.as_str() {
                 // Base metrics
-                "AV" => {
-                    cvss.attack_vector =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AC" => {
-                    cvss.attack_complexity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AT" => {
-                    cvss.attack_requirements =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "PR" => {
-                    cvss.privileges_required =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "UI" => {
-                    cvss.user_interaction =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "VC" => {
-                    cvss.vuln_confidentiality_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "VI" => {
-                    cvss.vuln_integrity_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "VA" => {
-                    cvss.vuln_availability_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "SC" => {
-                    cvss.sub_confidentiality_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "SI" => {
-                    cvss.sub_integrity_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "SA" => {
-                    cvss.sub_availability_impact =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "AV" => parse_metric(&mut cvss.attack_vector, &value, &key)?,
+                "AC" => parse_metric(&mut cvss.attack_complexity, &value, &key)?,
+                "AT" => parse_metric(&mut cvss.attack_requirements, &value, &key)?,
+                "PR" => parse_metric(&mut cvss.privileges_required, &value, &key)?,
+                "UI" => parse_metric(&mut cvss.user_interaction, &value, &key)?,
+                "VC" => parse_metric(&mut cvss.vuln_confidentiality_impact, &value, &key)?,
+                "VI" => parse_metric(&mut cvss.vuln_integrity_impact, &value, &key)?,
+                "VA" => parse_metric(&mut cvss.vuln_availability_impact, &value, &key)?,
+                "SC" => parse_metric(&mut cvss.sub_confidentiality_impact, &value, &key)?,
+                "SI" => parse_metric(&mut cvss.sub_integrity_impact, &value, &key)?,
+                "SA" => parse_metric(&mut cvss.sub_availability_impact, &value, &key)?,
                 // Threat metrics
-                "E" => {
-                    cvss.exploit_maturity =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "E" => parse_metric(&mut cvss.exploit_maturity, &value, &key)?,
                 // Environmental metrics
-                "CR" => {
-                    cvss.confidentiality_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "IR" => {
-                    cvss.integrity_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AR" => {
-                    cvss.availability_requirement =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "MAV" => {
-                    cvss.modified_attack_vector =
-                        Some(value.parse::<ModifiedAttackVector>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MAC" => {
-                    cvss.modified_attack_complexity =
-                        Some(value.parse::<ModifiedAttackComplexity>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MAT" => {
-                    cvss.modified_attack_requirements =
-                        Some(value.parse::<ModifiedAttackRequirements>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MPR" => {
-                    cvss.modified_privileges_required =
-                        Some(value.parse::<ModifiedPrivilegesRequired>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MUI" => {
-                    cvss.modified_user_interaction =
-                        Some(value.parse::<ModifiedUserInteraction>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
+                "CR" => parse_metric(&mut cvss.confidentiality_requirement, &value, &key)?,
+                "IR" => parse_metric(&mut cvss.integrity_requirement, &value, &key)?,
+                "AR" => parse_metric(&mut cvss.availability_requirement, &value, &key)?,
+                // Modified base metrics
+                "MAV" => parse_metric(&mut cvss.modified_attack_vector, &value, &key)?,
+                "MAC" => parse_metric(&mut cvss.modified_attack_complexity, &value, &key)?,
+                "MAT" => parse_metric(&mut cvss.modified_attack_requirements, &value, &key)?,
+                "MPR" => parse_metric(&mut cvss.modified_privileges_required, &value, &key)?,
+                "MUI" => parse_metric(&mut cvss.modified_user_interaction, &value, &key)?,
                 "MVC" => {
-                    cvss.modified_vuln_confidentiality_impact =
-                        Some(value.parse::<ModifiedImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
+                    parse_metric(&mut cvss.modified_vuln_confidentiality_impact, &value, &key)?
                 }
-                "MVI" => {
-                    cvss.modified_vuln_integrity_impact =
-                        Some(value.parse::<ModifiedImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MVA" => {
-                    cvss.modified_vuln_availability_impact =
-                        Some(value.parse::<ModifiedImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MSC" => {
-                    cvss.modified_sub_confidentiality_impact =
-                        Some(value.parse::<ModifiedSubsequentImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MSI" => {
-                    cvss.modified_sub_integrity_impact =
-                        Some(value.parse::<ModifiedSubsequentImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
-                "MSA" => {
-                    cvss.modified_sub_availability_impact =
-                        Some(value.parse::<ModifiedSubsequentImpact>().map_err(|_| {
-                            ParseError::InvalidMetricValue {
-                                metric: key.clone(),
-                                value: value.clone(),
-                            }
-                        })?);
-                }
+                "MVI" => parse_metric(&mut cvss.modified_vuln_integrity_impact, &value, &key)?,
+                "MVA" => parse_metric(&mut cvss.modified_vuln_availability_impact, &value, &key)?,
+                "MSC" => parse_metric(&mut cvss.modified_sub_confidentiality_impact, &value, &key)?,
+                "MSI" => parse_metric(&mut cvss.modified_sub_integrity_impact, &value, &key)?,
+                "MSA" => parse_metric(&mut cvss.modified_sub_availability_impact, &value, &key)?,
                 // Supplemental metrics
-                "S" => {
-                    cvss.safety =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "AU" => {
-                    cvss.automatable =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "R" => {
-                    cvss.recovery =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "V" => {
-                    cvss.value_density =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "RE" => {
-                    cvss.vulnerability_response_effort =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
-                "U" => {
-                    cvss.provider_urgency =
-                        Some(value.parse().map_err(|_| ParseError::InvalidMetricValue {
-                            metric: key.clone(),
-                            value: value.clone(),
-                        })?);
-                }
+                "S" => parse_metric(&mut cvss.safety, &value, &key)?,
+                "AU" => parse_metric(&mut cvss.automatable, &value, &key)?,
+                "R" => parse_metric(&mut cvss.recovery, &value, &key)?,
+                "V" => parse_metric(&mut cvss.value_density, &value, &key)?,
+                "RE" => parse_metric(&mut cvss.vulnerability_response_effort, &value, &key)?,
+                "U" => parse_metric(&mut cvss.provider_urgency, &value, &key)?,
                 _ => {
                     return Err(ParseError::UnknownMetric { metric: key });
                 }

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -1,5 +1,6 @@
 use cvss_rs as cvss;
-use cvss_rs::v2_0::CvssV2;
+use cvss_rs::{v2_0::CvssV2, ParseError};
+use rstest::rstest;
 use std::str::FromStr;
 
 #[test]
@@ -39,4 +40,29 @@ fn test_v2_0_multiple_unknown_metric_should_error_first() {
         CvssV2::from_str(vector),
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
+}
+
+#[rstest]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/AV:L", "AV")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/AC:H", "AC")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/Au:S", "AU")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/C:P", "C")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/I:P", "I")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/A:P", "A")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/E:H/E:POC", "E")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/RL:OF/RL:TF", "RL")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/RC:C/RC:UC", "RC")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/CDP:H/CDP:LM", "CDP")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/TD:H/TD:L", "TD")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/CR:H/CR:M", "CR")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/IR:H/IR:M", "IR")]
+#[case("AV:N/AC:L/Au:N/C:C/I:C/A:C/AR:H/AR:M", "AR")]
+fn test_v2_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expected_metric: &str) {
+    let result = vector.parse::<CvssV2>();
+    assert!(
+        matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
+        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
+        expected_metric,
+        result
+    );
 }

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -1,6 +1,7 @@
 use cvss::v3::AttackVector;
 use cvss_rs as cvss;
-use cvss_rs::v3::CvssV3;
+use cvss_rs::{v3::CvssV3, ParseError};
+use rstest::rstest;
 use std::str::FromStr;
 
 #[test]
@@ -101,4 +102,37 @@ fn test_v3_1_multiple_unknown_metric_should_error_first() {
         CvssV3::from_str(vector),
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
+}
+
+#[rstest]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/AV:L", "AV")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/AC:H", "AC")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/PR:H", "PR")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/UI:R", "UI")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/S:C", "S")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/C:L", "C")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/I:L", "I")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/A:L", "A")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/E:P", "E")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RL:W/RL:OF", "RL")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RC:C/RC:UC", "RC")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:H/CR:M", "CR")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/IR:H/IR:M", "IR")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/AR:H/AR:M", "AR")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MAV:L/MAV:A", "MAV")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MAC:H/MAC:L", "MAC")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MPR:L/MPR:N", "MPR")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MUI:R/MUI:N", "MUI")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MS:C/MS:U", "MS")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MC:L/MC:H", "MC")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MI:L/MI:H", "MI")]
+#[case("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MA:L/MA:H", "MA")]
+fn test_v3_1_duplicate_metrics_should_error(#[case] vector: &str, #[case] expected_metric: &str) {
+    let result = vector.parse::<CvssV3>();
+    assert!(
+        matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
+        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
+        expected_metric,
+        result
+    );
 }

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -1,5 +1,6 @@
 use cvss_rs as cvss;
-use cvss_rs::v4_0::CvssV4;
+use cvss_rs::{v4_0::CvssV4, ParseError};
+use rstest::rstest;
 use std::str::FromStr;
 
 #[test]
@@ -122,4 +123,36 @@ fn test_v4_0_multiple_unknown_metric_should_error_first() {
         CvssV4::from_str(vector),
         Err(cvss::ParseError::UnknownMetric { metric }) if metric == "XX"
     ));
+}
+
+#[rstest]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/AV:L", "AV")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/AC:H", "AC")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/AT:R", "AT")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/PR:H", "PR")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/UI:R", "UI")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/VC:L", "VC")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/VI:L", "VI")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/VA:L", "VA")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:L/SC:H", "SC")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SI:L/SI:H", "SI")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SA:L/SA:H", "SA")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/E:U/E:P", "E")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/CR:H/CR:M", "CR")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/IR:H/IR:M", "IR")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/AR:H/AR:M", "AR")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/S:P/S:N", "S")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/AU:Y/AU:N", "AU")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/R:A/R:U", "R")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/V:D/V:C", "V")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/RE:L/RE:M", "RE")]
+#[case("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/U:Clear/U:Red", "U")]
+fn test_v4_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expected_metric: &str) {
+    let result = vector.parse::<CvssV4>();
+    assert!(
+        matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
+        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
+        expected_metric,
+        result
+    );
 }


### PR DESCRIPTION
This PR:
* adds utils/parse_metrics.rs with the `parse_metric()` function, which abstracts the shared "take a metric value, check against enum, throw error if value is invalid" functionality of the v2,v3,v4 parsers
* extends the functionality of `parse_metric()` to include checking for duplicate metrics
* uses this function across the v2,v3,v4 parsers
* adds a rstest for each parser to pin the duplicate metric handling for each individual metric

Resolves #21 
No breaking changes apart from duplicate metrics now causing the parser to fail