### PR TITLE
fix: rename modifiedSubImpact variant NONE to NEGLIGIBLE

### DIFF
--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -385,7 +385,7 @@ pub enum ModifiedSubsequentImpact {
     #[strum(serialize = "L")]
     Low,
     #[strum(serialize = "N")]
-    None,
+    Negligible,
     #[strum(serialize = "X")]
     NotDefined,
 }

--- a/src/v4_0/scoring.rs
+++ b/src/v4_0/scoring.rs
@@ -163,7 +163,7 @@ fn merge_subsequent_impact(
         Some(ModifiedSubsequentImpact::Safety) => SubsequentImpact::Safety,
         Some(ModifiedSubsequentImpact::High) => SubsequentImpact::High,
         Some(ModifiedSubsequentImpact::Low) => SubsequentImpact::Low,
-        Some(ModifiedSubsequentImpact::None) => SubsequentImpact::None,
+        Some(ModifiedSubsequentImpact::Negligible) => SubsequentImpact::None,
     }
 }
 


### PR DESCRIPTION
As per the CVSS v4 spec: 
> Note: For MSC, MSI, and MSA, the lowest metric value is “Negligible” (N), not “None” (N).

Impact: JSON deserialization now correctly accepts `NEGLIGIBLE` as a valid ModifiedSubsequentImpact metric value (and rejects `NONE`), and serialization generates (more, still some bugs to be fixed at #15) schema-compliant JSON files.

This is part of #15 