### PR TITLE
feat: add web-based CVSS vector string validator

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-binstall
+        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+      - name: Install trunk
+        run: cargo binstall trunk --no-confirm --force
+
+      - name: Build
+        working-directory: web
+        run: trunk build --release --public-url /cvss-rs/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Cargo.lock
 /.serena
 /.idea
+/web/dist
+/web/dist.trunk-lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cvss-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.85"
 description = "A Rust library for representing and deserializing CVSS (Common Vulnerability Scoring System) data."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
+[workspace]
+members = [".", "web"]
+default-members = ["."]
+
+[workspace.package]
+version = "0.4.1"
+edition = "2024"
+
 [package]
 name = "cvss-rs"
-version = "0.4.1"
-edition = "2021"
-rust-version = "1.85"
+version.workspace = true
+edition.workspace = true
+rust-version = "1.88"
 description = "A Rust library for representing and deserializing CVSS (Common Vulnerability Scoring System) data."
 license = "Apache-2.0"
 repository = "https://github.com/scm-rs/cvss-rs"

--- a/src/v2_0.rs
+++ b/src/v2_0.rs
@@ -641,22 +641,22 @@ impl fmt::Display for CvssV2 {
         // CVSS v2 typically doesn't include version prefix, but we'll include it for consistency
         write!(f, "AV:")?;
         if let Some(av) = &self.access_vector {
-            write!(f, "{}", av)?;
+            write!(f, "{av}")?;
         }
         if let Some(ac) = &self.access_complexity {
-            write!(f, "/AC:{}", ac)?;
+            write!(f, "/AC:{ac}")?;
         }
         if let Some(au) = &self.authentication {
-            write!(f, "/Au:{}", au)?;
+            write!(f, "/Au:{au}")?;
         }
         if let Some(c) = &self.confidentiality_impact {
-            write!(f, "/C:{}", c)?;
+            write!(f, "/C:{c}")?;
         }
         if let Some(i) = &self.integrity_impact {
-            write!(f, "/I:{}", i)?;
+            write!(f, "/I:{i}")?;
         }
         if let Some(a) = &self.availability_impact {
-            write!(f, "/A:{}", a)?;
+            write!(f, "/A:{a}")?;
         }
 
         Ok(())

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
 use crate::utils::{parse_metrics::parse_metric, prefix};
-use crate::{version::VersionV3, ParseError, Severity as UnifiedSeverity, Version};
+use crate::{ParseError, Severity as UnifiedSeverity, Version, version::VersionV3};
 
 /// Represents a CVSS v3.0 or v3.1 score object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -725,78 +725,78 @@ impl fmt::Display for CvssV3 {
             "3.1"
         };
 
-        write!(f, "CVSS:{}", version)?;
+        write!(f, "CVSS:{version}")?;
 
         // Base metrics
         if let Some(av) = &self.attack_vector {
-            write!(f, "/AV:{}", av)?;
+            write!(f, "/AV:{av}")?;
         }
         if let Some(ac) = &self.attack_complexity {
-            write!(f, "/AC:{}", ac)?;
+            write!(f, "/AC:{ac}")?;
         }
         if let Some(pr) = &self.privileges_required {
-            write!(f, "/PR:{}", pr)?;
+            write!(f, "/PR:{pr}")?;
         }
         if let Some(ui) = &self.user_interaction {
-            write!(f, "/UI:{}", ui)?;
+            write!(f, "/UI:{ui}")?;
         }
         if let Some(s) = &self.scope {
-            write!(f, "/S:{}", s)?;
+            write!(f, "/S:{s}")?;
         }
         if let Some(c) = &self.confidentiality_impact {
-            write!(f, "/C:{}", c)?;
+            write!(f, "/C:{c}")?;
         }
         if let Some(i) = &self.integrity_impact {
-            write!(f, "/I:{}", i)?;
+            write!(f, "/I:{i}")?;
         }
         if let Some(a) = &self.availability_impact {
-            write!(f, "/A:{}", a)?;
+            write!(f, "/A:{a}")?;
         }
 
         // Temporal metrics
         if let Some(e) = &self.exploit_code_maturity {
-            write!(f, "/E:{}", e)?;
+            write!(f, "/E:{e}")?;
         }
         if let Some(rl) = &self.remediation_level {
-            write!(f, "/RL:{}", rl)?;
+            write!(f, "/RL:{rl}")?;
         }
         if let Some(rc) = &self.report_confidence {
-            write!(f, "/RC:{}", rc)?;
+            write!(f, "/RC:{rc}")?;
         }
 
         // Environmental metrics
         if let Some(cr) = &self.confidentiality_requirement {
-            write!(f, "/CR:{}", cr)?;
+            write!(f, "/CR:{cr}")?;
         }
         if let Some(ir) = &self.integrity_requirement {
-            write!(f, "/IR:{}", ir)?;
+            write!(f, "/IR:{ir}")?;
         }
         if let Some(ar) = &self.availability_requirement {
-            write!(f, "/AR:{}", ar)?;
+            write!(f, "/AR:{ar}")?;
         }
         if let Some(mav) = &self.modified_attack_vector {
-            write!(f, "/MAV:{}", mav)?;
+            write!(f, "/MAV:{mav}")?;
         }
         if let Some(mac) = &self.modified_attack_complexity {
-            write!(f, "/MAC:{}", mac)?;
+            write!(f, "/MAC:{mac}")?;
         }
         if let Some(mpr) = &self.modified_privileges_required {
-            write!(f, "/MPR:{}", mpr)?;
+            write!(f, "/MPR:{mpr}")?;
         }
         if let Some(mui) = &self.modified_user_interaction {
-            write!(f, "/MUI:{}", mui)?;
+            write!(f, "/MUI:{mui}")?;
         }
         if let Some(ms) = &self.modified_scope {
-            write!(f, "/MS:{}", ms)?;
+            write!(f, "/MS:{ms}")?;
         }
         if let Some(mc) = &self.modified_confidentiality_impact {
-            write!(f, "/MC:{}", mc)?;
+            write!(f, "/MC:{mc}")?;
         }
         if let Some(mi) = &self.modified_integrity_impact {
-            write!(f, "/MI:{}", mi)?;
+            write!(f, "/MI:{mi}")?;
         }
         if let Some(ma) = &self.modified_availability_impact {
-            write!(f, "/MA:{}", ma)?;
+            write!(f, "/MA:{ma}")?;
         }
 
         Ok(())

--- a/src/v4_0/lookup.rs
+++ b/src/v4_0/lookup.rs
@@ -319,7 +319,7 @@ pub(crate) fn max_composed(eq: VectorEq) -> Vec<&'static str> {
         VectorEq::Eq5(0) => vec!["E:A/"],
         VectorEq::Eq5(1) => vec!["E:P/"],
         VectorEq::Eq5(2) => vec!["E:U/"],
-        _ => panic!("Unexpected vector: {:?}", eq),
+        _ => panic!("Unexpected vector: {eq:?}"),
     }
 }
 
@@ -345,6 +345,6 @@ pub(crate) fn max_severity(eq: VectorEq) -> u8 {
         VectorEq::Eq5(0) => 1,
         VectorEq::Eq5(1) => 1,
         VectorEq::Eq5(2) => 1,
-        _ => panic!("Unexpected vector: {:?}", eq),
+        _ => panic!("Unexpected vector: {eq:?}"),
     }
 }

--- a/src/v4_0/mod.rs
+++ b/src/v4_0/mod.rs
@@ -719,106 +719,106 @@ impl fmt::Display for CvssV4 {
 
         // Base metrics
         if let Some(av) = &self.attack_vector {
-            write!(f, "/AV:{}", av)?;
+            write!(f, "/AV:{av}")?;
         }
         if let Some(ac) = &self.attack_complexity {
-            write!(f, "/AC:{}", ac)?;
+            write!(f, "/AC:{ac}")?;
         }
         if let Some(at) = &self.attack_requirements {
-            write!(f, "/AT:{}", at)?;
+            write!(f, "/AT:{at}")?;
         }
         if let Some(pr) = &self.privileges_required {
-            write!(f, "/PR:{}", pr)?;
+            write!(f, "/PR:{pr}")?;
         }
         if let Some(ui) = &self.user_interaction {
-            write!(f, "/UI:{}", ui)?;
+            write!(f, "/UI:{ui}")?;
         }
         if let Some(vc) = &self.vuln_confidentiality_impact {
-            write!(f, "/VC:{}", vc)?;
+            write!(f, "/VC:{vc}")?;
         }
         if let Some(vi) = &self.vuln_integrity_impact {
-            write!(f, "/VI:{}", vi)?;
+            write!(f, "/VI:{vi}")?;
         }
         if let Some(va) = &self.vuln_availability_impact {
-            write!(f, "/VA:{}", va)?;
+            write!(f, "/VA:{va}")?;
         }
         if let Some(sc) = &self.sub_confidentiality_impact {
-            write!(f, "/SC:{}", sc)?;
+            write!(f, "/SC:{sc}")?;
         }
         if let Some(si) = &self.sub_integrity_impact {
-            write!(f, "/SI:{}", si)?;
+            write!(f, "/SI:{si}")?;
         }
         if let Some(sa) = &self.sub_availability_impact {
-            write!(f, "/SA:{}", sa)?;
+            write!(f, "/SA:{sa}")?;
         }
 
         // Threat metrics
         if let Some(e) = &self.exploit_maturity {
-            write!(f, "/E:{}", e)?;
+            write!(f, "/E:{e}")?;
         }
 
         // Environmental metrics
         if let Some(cr) = &self.confidentiality_requirement {
-            write!(f, "/CR:{}", cr)?;
+            write!(f, "/CR:{cr}")?;
         }
         if let Some(ir) = &self.integrity_requirement {
-            write!(f, "/IR:{}", ir)?;
+            write!(f, "/IR:{ir}")?;
         }
         if let Some(ar) = &self.availability_requirement {
-            write!(f, "/AR:{}", ar)?;
+            write!(f, "/AR:{ar}")?;
         }
         if let Some(mav) = &self.modified_attack_vector {
-            write!(f, "/MAV:{}", mav)?;
+            write!(f, "/MAV:{mav}")?;
         }
         if let Some(mac) = &self.modified_attack_complexity {
-            write!(f, "/MAC:{}", mac)?;
+            write!(f, "/MAC:{mac}")?;
         }
         if let Some(mat) = &self.modified_attack_requirements {
-            write!(f, "/MAT:{}", mat)?;
+            write!(f, "/MAT:{mat}")?;
         }
         if let Some(mpr) = &self.modified_privileges_required {
-            write!(f, "/MPR:{}", mpr)?;
+            write!(f, "/MPR:{mpr}")?;
         }
         if let Some(mui) = &self.modified_user_interaction {
-            write!(f, "/MUI:{}", mui)?;
+            write!(f, "/MUI:{mui}")?;
         }
         if let Some(mvc) = &self.modified_vuln_confidentiality_impact {
-            write!(f, "/MVC:{}", mvc)?;
+            write!(f, "/MVC:{mvc}")?;
         }
         if let Some(mvi) = &self.modified_vuln_integrity_impact {
-            write!(f, "/MVI:{}", mvi)?;
+            write!(f, "/MVI:{mvi}")?;
         }
         if let Some(mva) = &self.modified_vuln_availability_impact {
-            write!(f, "/MVA:{}", mva)?;
+            write!(f, "/MVA:{mva}")?;
         }
         if let Some(msc) = &self.modified_sub_confidentiality_impact {
-            write!(f, "/MSC:{}", msc)?;
+            write!(f, "/MSC:{msc}")?;
         }
         if let Some(msi) = &self.modified_sub_integrity_impact {
-            write!(f, "/MSI:{}", msi)?;
+            write!(f, "/MSI:{msi}")?;
         }
         if let Some(msa) = &self.modified_sub_availability_impact {
-            write!(f, "/MSA:{}", msa)?;
+            write!(f, "/MSA:{msa}")?;
         }
 
         // Supplemental metrics
         if let Some(s) = &self.safety {
-            write!(f, "/S:{}", s)?;
+            write!(f, "/S:{s}")?;
         }
         if let Some(au) = &self.automatable {
-            write!(f, "/AU:{}", au)?;
+            write!(f, "/AU:{au}")?;
         }
         if let Some(r) = &self.recovery {
-            write!(f, "/R:{}", r)?;
+            write!(f, "/R:{r}")?;
         }
         if let Some(v) = &self.value_density {
-            write!(f, "/V:{}", v)?;
+            write!(f, "/V:{v}")?;
         }
         if let Some(re) = &self.vulnerability_response_effort {
-            write!(f, "/RE:{}", re)?;
+            write!(f, "/RE:{re}")?;
         }
         if let Some(u) = &self.provider_urgency {
-            write!(f, "/U:{}", u)?;
+            write!(f, "/U:{u}")?;
         }
 
         Ok(())

--- a/src/v4_0/scoring.rs
+++ b/src/v4_0/scoring.rs
@@ -363,11 +363,7 @@ pub fn calculate_score_internal(cvss: &CvssV4, include_threat_metrics: bool) -> 
             // 00 --> 01 or 00 --> 10 (take the higher score)
             let left = lookup_global(&macro_vector.incr_eq6());
             let right = lookup_global(&macro_vector.incr_eq3());
-            if left > right {
-                left
-            } else {
-                right
-            }
+            if left > right { left } else { right }
         } else {
             // 21 --> 32 (does not exist)
             lookup_global(&macro_vector.incr_eq3())
@@ -390,10 +386,8 @@ pub fn calculate_score_internal(cvss: &CvssV4, include_threat_metrics: bool) -> 
             for eq3_eq6_max in &eq3_eq6_maxes {
                 for eq4_max in &eq4_maxes {
                     for eq5_max in &eq5_maxes {
-                        max_vectors.push(format!(
-                            "{}{}{}{}{}",
-                            eq1_max, eq2_max, eq3_eq6_max, eq4_max, eq5_max
-                        ));
+                        max_vectors
+                            .push(format!("{eq1_max}{eq2_max}{eq3_eq6_max}{eq4_max}{eq5_max}"));
                     }
                 }
             }

--- a/tests/score_calculation_tests/v2_tests.rs
+++ b/tests/score_calculation_tests/v2_tests.rs
@@ -19,15 +19,14 @@ fn assert_v2_scores(
     expected_environmental: Option<f64>,
 ) {
     let cvss = CvssV2::from_str(vector)
-        .unwrap_or_else(|_| panic!("Failed to parse CVSS v2 vector: {}", vector));
+        .unwrap_or_else(|_| panic!("Failed to parse CVSS v2 vector: {vector}"));
 
     let calculated_base = cvss
         .calculated_base_score()
         .expect("Failed to calculate base score");
     assert_eq!(
         calculated_base, expected_base,
-        "Base score mismatch for vector: {}. Expected: {}, Calculated: {}",
-        vector, expected_base, calculated_base
+        "Base score mismatch for vector: {vector}. Expected: {expected_base}, Calculated: {calculated_base}"
     );
 
     if let Some(expected_temporal) = expected_temporal {
@@ -36,8 +35,7 @@ fn assert_v2_scores(
             .expect("Failed to calculate temporal score");
         assert_eq!(
             calculated_temporal, expected_temporal,
-            "Temporal score mismatch for vector: {}. Expected: {}, Calculated: {}",
-            vector, expected_temporal, calculated_temporal
+            "Temporal score mismatch for vector: {vector}. Expected: {expected_temporal}, Calculated: {calculated_temporal}"
         );
     }
 
@@ -47,8 +45,7 @@ fn assert_v2_scores(
             .expect("Failed to calculate environmental score");
         assert_eq!(
             calculated_environmental, expected_environmental,
-            "Environmental score mismatch for vector: {}. Expected: {}, Calculated: {}",
-            vector, expected_environmental, calculated_environmental
+            "Environmental score mismatch for vector: {vector}. Expected: {expected_environmental}, Calculated: {calculated_environmental}"
         );
     }
 }

--- a/tests/score_calculation_tests/v3_tests.rs
+++ b/tests/score_calculation_tests/v3_tests.rs
@@ -19,15 +19,14 @@ fn assert_v3_scores(
     expected_environmental: Option<f64>,
 ) {
     let cvss = CvssV3::from_str(vector)
-        .unwrap_or_else(|_| panic!("Failed to parse CVSS v3 vector: {}", vector));
+        .unwrap_or_else(|_| panic!("Failed to parse CVSS v3 vector: {vector}"));
 
     let calculated_base = cvss
         .calculated_base_score()
         .expect("Failed to calculate base score");
     assert_eq!(
         calculated_base, expected_base,
-        "Base score mismatch for vector: {}. Expected: {}, Calculated: {}",
-        vector, expected_base, calculated_base
+        "Base score mismatch for vector: {vector}. Expected: {expected_base}, Calculated: {calculated_base}"
     );
 
     if let Some(expected_temporal) = expected_temporal {
@@ -36,8 +35,7 @@ fn assert_v3_scores(
             .expect("Failed to calculate temporal score");
         assert_eq!(
             calculated_temporal, expected_temporal,
-            "Temporal score mismatch for vector: {}. Expected: {}, Calculated: {}",
-            vector, expected_temporal, calculated_temporal
+            "Temporal score mismatch for vector: {vector}. Expected: {expected_temporal}, Calculated: {calculated_temporal}"
         );
     }
 
@@ -47,8 +45,7 @@ fn assert_v3_scores(
             .expect("Failed to calculate environmental score");
         assert_eq!(
             calculated_environmental, expected_environmental,
-            "Environmental score mismatch for vector: {}. Expected: {}, Calculated: {}",
-            vector, expected_environmental, calculated_environmental
+            "Environmental score mismatch for vector: {vector}. Expected: {expected_environmental}, Calculated: {calculated_environmental}"
         );
     }
 }

--- a/tests/v2_tests.rs
+++ b/tests/v2_tests.rs
@@ -1,5 +1,5 @@
 use cvss_rs as cvss;
-use cvss_rs::{v2_0::CvssV2, ParseError};
+use cvss_rs::{ParseError, v2_0::CvssV2};
 use rstest::rstest;
 use std::str::FromStr;
 
@@ -61,8 +61,6 @@ fn test_v2_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
     let result = vector.parse::<CvssV2>();
     assert!(
         matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
-        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
-        expected_metric,
-        result
+        "Expected DuplicateMetric error for metric '{expected_metric}', but got: {result:?}"
     );
 }

--- a/tests/v3_tests.rs
+++ b/tests/v3_tests.rs
@@ -1,6 +1,6 @@
 use cvss::v3::AttackVector;
 use cvss_rs as cvss;
-use cvss_rs::{v3::CvssV3, ParseError};
+use cvss_rs::{ParseError, v3::CvssV3};
 use rstest::rstest;
 use std::str::FromStr;
 
@@ -34,7 +34,10 @@ fn test_v3_1_rounding_examples() {
         temporal_score, 9.6,
         "Temporal score should be 9.6 (with E/RL/RC = NotDefined)"
     );
-    assert_eq!(env_score, 9.7, "Environmental score should be 9.7 per CVSS v3.1 formula (with all env metrics = NotDefined)");
+    assert_eq!(
+        env_score, 9.7,
+        "Environmental score should be 9.7 per CVSS v3.1 formula (with all env metrics = NotDefined)"
+    );
 }
 
 #[test]
@@ -131,8 +134,6 @@ fn test_v3_1_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
     let result = vector.parse::<CvssV3>();
     assert!(
         matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
-        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
-        expected_metric,
-        result
+        "Expected DuplicateMetric error for metric '{expected_metric}', but got: {result:?}"
     );
 }

--- a/tests/v4_tests.rs
+++ b/tests/v4_tests.rs
@@ -1,5 +1,5 @@
 use cvss_rs as cvss;
-use cvss_rs::{v4_0::CvssV4, ParseError};
+use cvss_rs::{ParseError, v4_0::CvssV4};
 use rstest::rstest;
 use std::str::FromStr;
 
@@ -151,8 +151,6 @@ fn test_v4_0_duplicate_metrics_should_error(#[case] vector: &str, #[case] expect
     let result = vector.parse::<CvssV4>();
     assert!(
         matches!(result, Err(ParseError::DuplicateMetric { ref metric }) if metric == expected_metric),
-        "Expected DuplicateMetric error for metric '{}', but got: {:?}",
-        expected_metric,
-        result
+        "Expected DuplicateMetric error for metric '{expected_metric}', but got: {result:?}"
     );
 }

--- a/tests/walkall_tests.rs
+++ b/tests/walkall_tests.rs
@@ -103,7 +103,7 @@ fn test_walkall() -> anyhow::Result<()> {
     let failed = failed_files.lock().unwrap();
     if !failed.is_empty() {
         for (file, error) in failed.iter() {
-            eprintln!("Failed to process file: {:?}, error: {}", file, error);
+            eprintln!("Failed to process file: {file:?}, error: {error}");
         }
         bail!("{} files failed to process", failed.len());
     }
@@ -220,12 +220,12 @@ fn test_walkall() -> anyhow::Result<()> {
 
                 let redhat_status = match mismatch.redhat_score {
                     Some(rh) if (rh - mismatch.calculated_score).abs() < 0.05 => {
-                        format!("✓ RedHat agrees ({:.1}) - CVE DB error", rh)
+                        format!("✓ RedHat agrees ({rh:.1}) - CVE DB error")
                     }
                     Some(rh) if (rh - mismatch.expected_score).abs() < 0.05 => {
-                        format!("✗ RedHat agrees with JSON ({:.1}) - impl issue", rh)
+                        format!("✗ RedHat agrees with JSON ({rh:.1}) - impl issue")
                     }
-                    Some(rh) => format!("? RedHat differs ({:.1})", rh),
+                    Some(rh) => format!("? RedHat differs ({rh:.1})"),
                     None => "? RedHat unavailable".to_string(),
                 };
 
@@ -251,29 +251,29 @@ fn test_walkall() -> anyhow::Result<()> {
                     .unwrap_or("unknown");
                 let base = mismatch
                     .base_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
                 let temporal = mismatch
                     .temporal_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
                 let env = mismatch
                     .environmental_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
 
                 // Red Hat returns base score, so compare with our base_score
                 let redhat_status = match (mismatch.redhat_score, mismatch.base_score) {
                     (Some(rh), Some(base)) if (rh - base).abs() < 0.05 => {
-                        format!("✓ RedHat agrees ({:.1}) - CVE DB error", rh)
+                        format!("✓ RedHat agrees ({rh:.1}) - CVE DB error")
                     }
                     (Some(rh), _) if (rh - mismatch.expected_score).abs() < 0.05 => {
-                        format!("✗ RedHat agrees with JSON ({:.1}) - impl issue", rh)
+                        format!("✗ RedHat agrees with JSON ({rh:.1}) - impl issue")
                     }
                     (Some(rh), Some(base)) => {
-                        format!("? RedHat ({:.1}) vs our base ({:.1})", rh, base)
+                        format!("? RedHat ({rh:.1}) vs our base ({base:.1})")
                     }
-                    (Some(rh), None) => format!("? RedHat: {:.1}", rh),
+                    (Some(rh), None) => format!("? RedHat: {rh:.1}"),
                     (None, _) => "? RedHat unavailable".to_string(),
                 };
 
@@ -302,29 +302,29 @@ fn test_walkall() -> anyhow::Result<()> {
                     .unwrap_or("unknown");
                 let base = mismatch
                     .base_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
                 let temporal = mismatch
                     .temporal_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
                 let env = mismatch
                     .environmental_score
-                    .map(|s| format!("{:.1}", s))
+                    .map(|s| format!("{s:.1}"))
                     .unwrap_or_else(|| "N/A".to_string());
 
                 // Red Hat returns base score, so compare with our base_score
                 let redhat_status = match (mismatch.redhat_score, mismatch.base_score) {
                     (Some(rh), Some(base)) if (rh - base).abs() < 0.05 => {
-                        format!("✓ RedHat agrees ({:.1}) - CVE DB error", rh)
+                        format!("✓ RedHat agrees ({rh:.1}) - CVE DB error")
                     }
                     (Some(rh), _) if (rh - mismatch.expected_score).abs() < 0.05 => {
-                        format!("✗ RedHat agrees with JSON ({:.1}) - impl issue", rh)
+                        format!("✗ RedHat agrees with JSON ({rh:.1}) - impl issue")
                     }
                     (Some(rh), Some(base)) => {
-                        format!("? RedHat ({:.1}) vs our base ({:.1})", rh, base)
+                        format!("? RedHat ({rh:.1}) vs our base ({base:.1})")
                     }
-                    (Some(rh), None) => format!("? RedHat: {:.1}", rh),
+                    (Some(rh), None) => format!("? RedHat: {rh:.1}"),
                     (None, _) => "? RedHat unavailable".to_string(),
                 };
 
@@ -366,16 +366,13 @@ fn test_walkall() -> anyhow::Result<()> {
         println!("║                         MISMATCH SUMMARY                          ║");
         println!("╠═══════════════════════════════════════════════════════════════════╣");
         println!(
-            "║ Total mismatches:         {:>5}                                   ║",
-            total_mismatches
+            "║ Total mismatches:         {total_mismatches:>5}                                   ║"
         );
         println!(
-            "║ CVE DB errors (verified): {:>5}                                   ║",
-            cve_db_errors
+            "║ CVE DB errors (verified): {cve_db_errors:>5}                                   ║"
         );
         println!(
-            "║ Implementation issues:    {:>5}                                   ║",
-            implementation_issues
+            "║ Implementation issues:    {implementation_issues:>5}                                   ║"
         );
         println!(
             "║ V4.0 (unverified):        {:>5}                                   ║",
@@ -384,18 +381,14 @@ fn test_walkall() -> anyhow::Result<()> {
         println!("╚═══════════════════════════════════════════════════════════════════╝\n");
 
         if implementation_issues > 0 {
-            bail!(
-                "Found {} implementation issues that need fixing",
-                implementation_issues
-            );
+            bail!("Found {implementation_issues} implementation issues that need fixing");
         } else if !v4_mismatches.is_empty() {
             println!(
                 "Note: {} V4.0 mismatches found but Red Hat verification unavailable",
                 v4_mismatches.len()
             );
             println!(
-                "V3.x implementation verified as correct by Red Hat ({} CVE DB errors confirmed)",
-                cve_db_errors
+                "V3.x implementation verified as correct by Red Hat ({cve_db_errors} CVE DB errors confirmed)"
             );
         } else {
             println!("All mismatches verified as CVE database errors - implementation is correct!");
@@ -456,10 +449,10 @@ fn verify_with_redhat(vector: &str) -> Option<f64> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
-        if line.starts_with("Base Score:") {
-            if let Some(score_str) = line.split_whitespace().nth(2) {
-                return score_str.parse().ok();
-            }
+        if line.starts_with("Base Score:")
+            && let Some(score_str) = line.split_whitespace().nth(2)
+        {
+            return score_str.parse().ok();
         }
     }
     None
@@ -467,8 +460,8 @@ fn verify_with_redhat(vector: &str) -> Option<f64> {
 
 fn process(path: &Path) -> anyhow::Result<ProcessResult> {
     let content = fs::read(path)?;
-    let cve: CveRoot = serde_json::from_slice(&content)
-        .map_err(|e| anyhow!("Failed to deserialize CVE: {}", e))?;
+    let cve: CveRoot =
+        serde_json::from_slice(&content).map_err(|e| anyhow!("Failed to deserialize CVE: {e}"))?;
 
     let mut stats = ScoreStats::default();
     let mut mismatches = Vec::new();
@@ -482,7 +475,7 @@ fn process(path: &Path) -> anyhow::Result<ProcessResult> {
 
                 // Validate JSON score range
                 if !(0.0..=10.0).contains(&json_score) {
-                    bail!("Invalid V2.0 base_score: {}", json_score);
+                    bail!("Invalid V2.0 base_score: {json_score}");
                 }
 
                 // Parse vector and calculate score
@@ -546,7 +539,7 @@ fn process(path: &Path) -> anyhow::Result<ProcessResult> {
                 let json_score = v3_0.base_score;
 
                 if !(0.0..=10.0).contains(&json_score) {
-                    bail!("Invalid V3.0 base_score: {}", json_score);
+                    bail!("Invalid V3.0 base_score: {json_score}");
                 }
 
                 if let Ok(parsed) = CvssV3::from_str(&v3_0.vector_string) {
@@ -607,7 +600,7 @@ fn process(path: &Path) -> anyhow::Result<ProcessResult> {
                 let json_score = v3_1.base_score;
 
                 if !(0.0..=10.0).contains(&json_score) {
-                    bail!("Invalid V3.1 base_score: {}", json_score);
+                    bail!("Invalid V3.1 base_score: {json_score}");
                 }
 
                 if let Ok(parsed) = CvssV3::from_str(&v3_1.vector_string) {
@@ -668,7 +661,7 @@ fn process(path: &Path) -> anyhow::Result<ProcessResult> {
                 let json_score = v4.base_score;
 
                 if !(0.0..=10.0).contains(&json_score) {
-                    bail!("Invalid V4.0 base_score: {}", json_score);
+                    bail!("Invalid V4.0 base_score: {json_score}");
                 }
 
                 // Calculate with our implementation - try BOTH base score and full score

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cvss-web"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+js-sys = "0.3"
+leptos = { version = "0.8", features = ["csr"] }
+cvss-rs = { path = ".." }
+wasm-bindgen = "0.2"
+
+[dependencies.web-sys]
+version = "0.3"
+features = ["Clipboard", "History", "Navigator", "UrlSearchParams"]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CVSS Vector Validator</title>
+    <link data-trunk rel="css" href="style/main.css" />
+</head>
+<body></body>
+</html>

--- a/web/rust-toolchain.toml
+++ b/web/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,0 +1,858 @@
+use std::str::FromStr;
+
+use leptos::prelude::*;
+use wasm_bindgen::JsValue;
+
+use cvss_rs::ParseError;
+use cvss_rs::v2_0::CvssV2;
+use cvss_rs::v3::CvssV3;
+use cvss_rs::v4_0::CvssV4;
+
+fn main() {
+    leptos::mount::mount_to_body(|| view! { <App /> });
+}
+
+/// Result of parsing a CVSS vector string, dispatched by version.
+enum ParsedCvss {
+    V2(CvssV2),
+    V3(CvssV3),
+    V4(CvssV4),
+}
+
+/// Auto-detects the CVSS version from the vector prefix and parses accordingly.
+fn parse_cvss_vector(input: &str) -> Result<ParsedCvss, ParseError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(ParseError::InvalidPrefixLabel {
+            found: String::new(),
+        });
+    }
+
+    let upper = trimmed.to_ascii_uppercase();
+    if upper.starts_with("CVSS:4.0/") {
+        CvssV4::from_str(trimmed).map(ParsedCvss::V4)
+    } else if upper.starts_with("CVSS:3.1/") || upper.starts_with("CVSS:3.0/") {
+        CvssV3::from_str(trimmed).map(ParsedCvss::V3)
+    } else if upper.starts_with("CVSS:2.0/") {
+        CvssV2::from_str(trimmed).map(ParsedCvss::V2)
+    } else if upper.starts_with("CVSS:") {
+        let version = upper
+            .split('/')
+            .next()
+            .and_then(|s| s.strip_prefix("CVSS:"))
+            .unwrap_or("unknown");
+        Err(ParseError::InvalidPrefixVersion {
+            version: version.to_string(),
+        })
+    } else {
+        CvssV2::from_str(trimmed).map(ParsedCvss::V2)
+    }
+}
+
+/// Reads the `?vector=` query parameter from the current URL.
+fn initial_vector() -> String {
+    web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .and_then(|s| web_sys::UrlSearchParams::new_with_str(&s).ok())
+        .and_then(|p| p.get("vector"))
+        .unwrap_or_default()
+}
+
+/// Builds a shareable URL with the vector as a query parameter.
+fn build_share_url(vector: &str) -> Option<String> {
+    let window = web_sys::window()?;
+    let location = window.location();
+    let origin = location.origin().ok()?;
+    let pathname = location.pathname().ok()?;
+    let encoded = js_sys::encode_uri_component(vector);
+    Some(format!("{origin}{pathname}?vector={encoded}"))
+}
+
+/// Derives a severity label from a calculated score using CVSS v3/v4 thresholds.
+fn severity_from_score(score: f64) -> &'static str {
+    if score == 0.0 {
+        "None"
+    } else if score <= 3.9 {
+        "Low"
+    } else if score <= 6.9 {
+        "Medium"
+    } else if score <= 8.9 {
+        "High"
+    } else {
+        "Critical"
+    }
+}
+
+/// Derives a severity label from a calculated score using CVSS v2 thresholds.
+fn severity_from_score_v2(score: f64) -> &'static str {
+    if score <= 3.9 {
+        "Low"
+    } else if score <= 6.9 {
+        "Medium"
+    } else {
+        "High"
+    }
+}
+
+/// Returns the CSS class for a severity label.
+fn severity_class(severity: &str) -> &'static str {
+    match severity {
+        "None" => "severity-none",
+        "Low" => "severity-low",
+        "Medium" => "severity-medium",
+        "High" => "severity-high",
+        "Critical" => "severity-critical",
+        _ => "severity-none",
+    }
+}
+
+#[component]
+fn App() -> impl IntoView {
+    let (input, set_input) = signal(initial_vector());
+    let (copied, set_copied) = signal(false);
+
+    let result = move || {
+        let value = input.get();
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(parse_cvss_vector(&value))
+        }
+    };
+
+    Effect::new(move |_| {
+        let value = input.get();
+        if let Some(window) = web_sys::window()
+            && let Ok(history) = window.history()
+        {
+            let url = if value.trim().is_empty() {
+                window
+                    .location()
+                    .pathname()
+                    .unwrap_or_else(|_| "/".to_string())
+            } else {
+                let encoded = js_sys::encode_uri_component(&value);
+                let pathname = window
+                    .location()
+                    .pathname()
+                    .unwrap_or_else(|_| "/".to_string());
+                format!("{pathname}?vector={encoded}")
+            };
+            let _ = history.replace_state_with_url(&JsValue::NULL, "", Some(&url));
+        }
+    });
+
+    let copy_link = move |_| {
+        let value = input.get();
+        if let Some(url) = build_share_url(&value)
+            && let Some(window) = web_sys::window()
+        {
+            let clipboard = window.navigator().clipboard();
+            let _ = clipboard.write_text(&url);
+            set_copied.set(true);
+            let handle = set_timeout_with_handle(
+                move || set_copied.set(false),
+                std::time::Duration::from_secs(2),
+            );
+            let _ = handle;
+        }
+    };
+
+    view! {
+        <div class="container">
+            <header>
+                <h1>
+                    <span class="badge">"CVSS"</span>
+                    " Vector Validator"
+                </h1>
+                <p class="subtitle">
+                    "Validate and inspect "
+                    <a href="https://www.first.org/cvss/" target="_blank" rel="noopener">
+                        "CVSS"
+                    </a>
+                    " vector strings (v2.0, v3.0, v3.1, v4.0)"
+                </p>
+            </header>
+
+            <div class="input-row">
+                <input
+                    type="text"
+                    class="vector-input"
+                    placeholder="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                    prop:value=move || input.get()
+                    on:input=move |ev| set_input.set(event_target_value(&ev))
+                />
+                <button
+                    class="share-btn"
+                    class:copied=move || copied.get()
+                    on:click=copy_link
+                    disabled=move || input.get().trim().is_empty()
+                >
+                    {move || if copied.get() { "Copied!" } else { "Share" }}
+                </button>
+            </div>
+
+            <div class="result-area">
+                {move || match result() {
+                    None => view! {
+                        <p class="hint">"Enter a CVSS vector string above to validate it."</p>
+                    }.into_any(),
+                    Some(Err(err)) => view! {
+                        <div class="error">
+                            <strong>"Parse Error"</strong>
+                            <p>{err.to_string()}</p>
+                        </div>
+                    }.into_any(),
+                    Some(Ok(parsed)) => view! {
+                        <CvssResult parsed=parsed />
+                    }.into_any(),
+                }}
+            </div>
+
+            <footer>
+                <a href="https://github.com/scm-rs/cvss-rs" target="_blank" rel="noopener">
+                    "cvss-rs"
+                </a>
+            </footer>
+        </div>
+    }
+}
+
+/// A single row in a metric table.
+struct MetricEntry {
+    abbr: &'static str,
+    name: &'static str,
+    value: String,
+}
+
+/// Renders a table of metrics with a group header.
+#[component]
+fn MetricGroup(title: &'static str, entries: Vec<MetricEntry>) -> impl IntoView {
+    if entries.is_empty() {
+        return ().into_any();
+    }
+    view! {
+        <div class="metric-group">
+            <h3>{title}</h3>
+            <table class="metrics">
+                {entries.into_iter().map(|e| view! {
+                    <tr>
+                        <td class="metric-abbr"><code>{e.abbr}</code></td>
+                        <td class="metric-name">{e.name}</td>
+                        <td class="metric-value"><code>{e.value}</code></td>
+                    </tr>
+                }).collect::<Vec<_>>()}
+            </table>
+        </div>
+    }
+    .into_any()
+}
+
+/// Displays the full parsed CVSS result with scores and metrics.
+#[component]
+fn CvssResult(parsed: ParsedCvss) -> impl IntoView {
+    match parsed {
+        ParsedCvss::V2(cvss) => render_v2(cvss).into_any(),
+        ParsedCvss::V3(cvss) => render_v3(cvss).into_any(),
+        ParsedCvss::V4(cvss) => render_v4(cvss).into_any(),
+    }
+}
+
+/// Renders a score banner with version label, score, and severity.
+#[component]
+fn ScoreBanner(
+    version: &'static str,
+    score: Option<f64>,
+    severity: &'static str,
+    #[prop(optional)] nomenclature: String,
+) -> impl IntoView {
+    let score_text = score
+        .map(|s| format!("{s:.1}"))
+        .unwrap_or_else(|| "N/A".to_string());
+    let sev_class = severity_class(severity);
+    let show_nomenclature = if nomenclature.is_empty() {
+        None
+    } else {
+        Some(nomenclature)
+    };
+
+    view! {
+        <div class="score-banner">
+            <span class="version-badge">{version}</span>
+            {show_nomenclature.map(|n| view! { <span class="nomenclature-badge">{n}</span> })}
+            <span class=format!("score {sev_class}")>{score_text}</span>
+            <span class=format!("severity-label {sev_class}")>{severity}</span>
+        </div>
+    }
+}
+
+/// Renders the parsed CVSS v2.0 result.
+fn render_v2(cvss: CvssV2) -> impl IntoView {
+    let base_score = cvss.calculated_base_score();
+    let temporal_score = cvss.calculated_temporal_score();
+    let environmental_score = cvss.calculated_environmental_score();
+    let severity = base_score.map(severity_from_score_v2).unwrap_or("None");
+
+    let mut base = Vec::new();
+    if let Some(v) = &cvss.access_vector {
+        base.push(MetricEntry {
+            abbr: "AV",
+            name: "Access Vector",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.access_complexity {
+        base.push(MetricEntry {
+            abbr: "AC",
+            name: "Access Complexity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.authentication {
+        base.push(MetricEntry {
+            abbr: "Au",
+            name: "Authentication",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.confidentiality_impact {
+        base.push(MetricEntry {
+            abbr: "C",
+            name: "Confidentiality Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.integrity_impact {
+        base.push(MetricEntry {
+            abbr: "I",
+            name: "Integrity Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.availability_impact {
+        base.push(MetricEntry {
+            abbr: "A",
+            name: "Availability Impact",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut temporal = Vec::new();
+    if let Some(v) = &cvss.exploitability {
+        temporal.push(MetricEntry {
+            abbr: "E",
+            name: "Exploitability",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.remediation_level {
+        temporal.push(MetricEntry {
+            abbr: "RL",
+            name: "Remediation Level",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.report_confidence {
+        temporal.push(MetricEntry {
+            abbr: "RC",
+            name: "Report Confidence",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut environmental = Vec::new();
+    if let Some(v) = &cvss.collateral_damage_potential {
+        environmental.push(MetricEntry {
+            abbr: "CDP",
+            name: "Collateral Damage Potential",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.target_distribution {
+        environmental.push(MetricEntry {
+            abbr: "TD",
+            name: "Target Distribution",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.confidentiality_requirement {
+        environmental.push(MetricEntry {
+            abbr: "CR",
+            name: "Confidentiality Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.integrity_requirement {
+        environmental.push(MetricEntry {
+            abbr: "IR",
+            name: "Integrity Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.availability_requirement {
+        environmental.push(MetricEntry {
+            abbr: "AR",
+            name: "Availability Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+
+    view! {
+        <div class="success">
+            <ScoreBanner version="CVSS v2.0" score=base_score severity=severity />
+            <div class="scores-detail">
+                {temporal_score.map(|s| view! {
+                    <span class="score-item">"Temporal: " <strong>{format!("{s:.1}")}</strong></span>
+                })}
+                {environmental_score.map(|s| view! {
+                    <span class="score-item">"Environmental: " <strong>{format!("{s:.1}")}</strong></span>
+                })}
+            </div>
+            <MetricGroup title="Base Metrics" entries=base />
+            <MetricGroup title="Temporal Metrics" entries=temporal />
+            <MetricGroup title="Environmental Metrics" entries=environmental />
+        </div>
+    }
+}
+
+/// Renders the parsed CVSS v3.x result.
+fn render_v3(cvss: CvssV3) -> impl IntoView {
+    let version_label = match &cvss.version {
+        Some(v) => match v {
+            cvss_rs::version::VersionV3::V3_0 => "CVSS v3.0",
+            cvss_rs::version::VersionV3::V3_1 => "CVSS v3.1",
+        },
+        None => "CVSS v3.x",
+    };
+    let base_score = cvss.calculated_base_score();
+    let temporal_score = cvss.calculated_temporal_score();
+    let environmental_score = cvss.calculated_environmental_score();
+    let severity = base_score.map(severity_from_score).unwrap_or("None");
+
+    let mut base = Vec::new();
+    if let Some(v) = &cvss.attack_vector {
+        base.push(MetricEntry {
+            abbr: "AV",
+            name: "Attack Vector",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.attack_complexity {
+        base.push(MetricEntry {
+            abbr: "AC",
+            name: "Attack Complexity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.privileges_required {
+        base.push(MetricEntry {
+            abbr: "PR",
+            name: "Privileges Required",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.user_interaction {
+        base.push(MetricEntry {
+            abbr: "UI",
+            name: "User Interaction",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.scope {
+        base.push(MetricEntry {
+            abbr: "S",
+            name: "Scope",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.confidentiality_impact {
+        base.push(MetricEntry {
+            abbr: "C",
+            name: "Confidentiality Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.integrity_impact {
+        base.push(MetricEntry {
+            abbr: "I",
+            name: "Integrity Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.availability_impact {
+        base.push(MetricEntry {
+            abbr: "A",
+            name: "Availability Impact",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut temporal = Vec::new();
+    if let Some(v) = &cvss.exploit_code_maturity {
+        temporal.push(MetricEntry {
+            abbr: "E",
+            name: "Exploit Code Maturity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.remediation_level {
+        temporal.push(MetricEntry {
+            abbr: "RL",
+            name: "Remediation Level",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.report_confidence {
+        temporal.push(MetricEntry {
+            abbr: "RC",
+            name: "Report Confidence",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut environmental = Vec::new();
+    if let Some(v) = &cvss.confidentiality_requirement {
+        environmental.push(MetricEntry {
+            abbr: "CR",
+            name: "Confidentiality Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.integrity_requirement {
+        environmental.push(MetricEntry {
+            abbr: "IR",
+            name: "Integrity Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.availability_requirement {
+        environmental.push(MetricEntry {
+            abbr: "AR",
+            name: "Availability Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_attack_vector {
+        environmental.push(MetricEntry {
+            abbr: "MAV",
+            name: "Modified Attack Vector",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_attack_complexity {
+        environmental.push(MetricEntry {
+            abbr: "MAC",
+            name: "Modified Attack Complexity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_privileges_required {
+        environmental.push(MetricEntry {
+            abbr: "MPR",
+            name: "Modified Privileges Required",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_user_interaction {
+        environmental.push(MetricEntry {
+            abbr: "MUI",
+            name: "Modified User Interaction",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_scope {
+        environmental.push(MetricEntry {
+            abbr: "MS",
+            name: "Modified Scope",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_confidentiality_impact {
+        environmental.push(MetricEntry {
+            abbr: "MC",
+            name: "Modified Confidentiality Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_integrity_impact {
+        environmental.push(MetricEntry {
+            abbr: "MI",
+            name: "Modified Integrity Impact",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_availability_impact {
+        environmental.push(MetricEntry {
+            abbr: "MA",
+            name: "Modified Availability Impact",
+            value: format!("{v:?}"),
+        });
+    }
+
+    view! {
+        <div class="success">
+            <ScoreBanner version=version_label score=base_score severity=severity />
+            <div class="scores-detail">
+                {temporal_score.map(|s| view! {
+                    <span class="score-item">"Temporal: " <strong>{format!("{s:.1}")}</strong></span>
+                })}
+                {environmental_score.map(|s| view! {
+                    <span class="score-item">"Environmental: " <strong>{format!("{s:.1}")}</strong></span>
+                })}
+            </div>
+            <MetricGroup title="Base Metrics" entries=base />
+            <MetricGroup title="Temporal Metrics" entries=temporal />
+            <MetricGroup title="Environmental Metrics" entries=environmental />
+        </div>
+    }
+}
+
+/// Renders the parsed CVSS v4.0 result.
+fn render_v4(cvss: CvssV4) -> impl IntoView {
+    let score_info = cvss.calculated_score();
+    let score = score_info.as_ref().map(|(s, _)| *s);
+    let nomenclature = score_info.map(|(_, n)| n.to_string());
+    let severity = score.map(severity_from_score).unwrap_or("None");
+
+    let mut base = Vec::new();
+    if let Some(v) = &cvss.attack_vector {
+        base.push(MetricEntry {
+            abbr: "AV",
+            name: "Attack Vector",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.attack_complexity {
+        base.push(MetricEntry {
+            abbr: "AC",
+            name: "Attack Complexity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.attack_requirements {
+        base.push(MetricEntry {
+            abbr: "AT",
+            name: "Attack Requirements",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.privileges_required {
+        base.push(MetricEntry {
+            abbr: "PR",
+            name: "Privileges Required",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.user_interaction {
+        base.push(MetricEntry {
+            abbr: "UI",
+            name: "User Interaction",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.vuln_confidentiality_impact {
+        base.push(MetricEntry {
+            abbr: "VC",
+            name: "Vuln. Confidentiality",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.vuln_integrity_impact {
+        base.push(MetricEntry {
+            abbr: "VI",
+            name: "Vuln. Integrity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.vuln_availability_impact {
+        base.push(MetricEntry {
+            abbr: "VA",
+            name: "Vuln. Availability",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.sub_confidentiality_impact {
+        base.push(MetricEntry {
+            abbr: "SC",
+            name: "Sub. Confidentiality",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.sub_integrity_impact {
+        base.push(MetricEntry {
+            abbr: "SI",
+            name: "Sub. Integrity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.sub_availability_impact {
+        base.push(MetricEntry {
+            abbr: "SA",
+            name: "Sub. Availability",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut threat = Vec::new();
+    if let Some(v) = &cvss.exploit_maturity {
+        threat.push(MetricEntry {
+            abbr: "E",
+            name: "Exploit Maturity",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut environmental = Vec::new();
+    if let Some(v) = &cvss.confidentiality_requirement {
+        environmental.push(MetricEntry {
+            abbr: "CR",
+            name: "Confidentiality Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.integrity_requirement {
+        environmental.push(MetricEntry {
+            abbr: "IR",
+            name: "Integrity Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.availability_requirement {
+        environmental.push(MetricEntry {
+            abbr: "AR",
+            name: "Availability Requirement",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_attack_vector {
+        environmental.push(MetricEntry {
+            abbr: "MAV",
+            name: "Modified Attack Vector",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_attack_complexity {
+        environmental.push(MetricEntry {
+            abbr: "MAC",
+            name: "Modified Attack Complexity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_attack_requirements {
+        environmental.push(MetricEntry {
+            abbr: "MAT",
+            name: "Modified Attack Requirements",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_privileges_required {
+        environmental.push(MetricEntry {
+            abbr: "MPR",
+            name: "Modified Privileges Required",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_user_interaction {
+        environmental.push(MetricEntry {
+            abbr: "MUI",
+            name: "Modified User Interaction",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_vuln_confidentiality_impact {
+        environmental.push(MetricEntry {
+            abbr: "MVC",
+            name: "Modified Vuln. Confidentiality",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_vuln_integrity_impact {
+        environmental.push(MetricEntry {
+            abbr: "MVI",
+            name: "Modified Vuln. Integrity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_vuln_availability_impact {
+        environmental.push(MetricEntry {
+            abbr: "MVA",
+            name: "Modified Vuln. Availability",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_sub_confidentiality_impact {
+        environmental.push(MetricEntry {
+            abbr: "MSC",
+            name: "Modified Sub. Confidentiality",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_sub_integrity_impact {
+        environmental.push(MetricEntry {
+            abbr: "MSI",
+            name: "Modified Sub. Integrity",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.modified_sub_availability_impact {
+        environmental.push(MetricEntry {
+            abbr: "MSA",
+            name: "Modified Sub. Availability",
+            value: format!("{v:?}"),
+        });
+    }
+
+    let mut supplemental = Vec::new();
+    if let Some(v) = &cvss.safety {
+        supplemental.push(MetricEntry {
+            abbr: "S",
+            name: "Safety",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.automatable {
+        supplemental.push(MetricEntry {
+            abbr: "AU",
+            name: "Automatable",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.recovery {
+        supplemental.push(MetricEntry {
+            abbr: "R",
+            name: "Recovery",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.value_density {
+        supplemental.push(MetricEntry {
+            abbr: "V",
+            name: "Value Density",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.vulnerability_response_effort {
+        supplemental.push(MetricEntry {
+            abbr: "RE",
+            name: "Response Effort",
+            value: format!("{v:?}"),
+        });
+    }
+    if let Some(v) = &cvss.provider_urgency {
+        supplemental.push(MetricEntry {
+            abbr: "U",
+            name: "Provider Urgency",
+            value: format!("{v:?}"),
+        });
+    }
+
+    view! {
+        <div class="success">
+            <ScoreBanner version="CVSS v4.0" score=score severity=severity nomenclature=nomenclature.unwrap_or_default() />
+            <MetricGroup title="Base Metrics" entries=base />
+            <MetricGroup title="Threat Metrics" entries=threat />
+            <MetricGroup title="Environmental Metrics" entries=environmental />
+            <MetricGroup title="Supplemental Metrics" entries=supplemental />
+        </div>
+    }
+}

--- a/web/style/main.css
+++ b/web/style/main.css
@@ -1,0 +1,335 @@
+:root {
+    --bg: #ffffff;
+    --fg: #1a1a2e;
+    --bg-secondary: #f5f5f7;
+    --border: #d1d1d6;
+    --accent: #0071e3;
+    --accent-hover: #0060c0;
+    --input-bg: #ffffff;
+    --input-border: #c7c7cc;
+    --input-focus: #0071e3;
+    --code-bg: #f0f0f3;
+    --success-bg: #e8f5e9;
+    --success-border: #4caf50;
+    --error-bg: #fdecea;
+    --error-border: #f44336;
+    --error-fg: #c62828;
+    --hint-fg: #8e8e93;
+    --font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+
+    --severity-none: #636366;
+    --severity-none-bg: #f0f0f3;
+    --severity-low: #34c759;
+    --severity-low-bg: #e8f5e9;
+    --severity-medium: #f5a623;
+    --severity-medium-bg: #fff8e1;
+    --severity-high: #ff6b35;
+    --severity-high-bg: #fff3e0;
+    --severity-critical: #ff3b30;
+    --severity-critical-bg: #fdecea;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #1c1c1e;
+        --fg: #f5f5f7;
+        --bg-secondary: #2c2c2e;
+        --border: #48484a;
+        --accent: #0a84ff;
+        --accent-hover: #409cff;
+        --input-bg: #2c2c2e;
+        --input-border: #48484a;
+        --input-focus: #0a84ff;
+        --code-bg: #3a3a3c;
+        --success-bg: #1b3a1b;
+        --success-border: #4caf50;
+        --error-bg: #3a1b1b;
+        --error-border: #f44336;
+        --error-fg: #ef9a9a;
+        --hint-fg: #98989d;
+
+        --severity-none: #98989d;
+        --severity-none-bg: #2c2c2e;
+        --severity-low: #30d158;
+        --severity-low-bg: #1b3a1b;
+        --severity-medium: #ffd60a;
+        --severity-medium-bg: #3a351b;
+        --severity-high: #ff9f0a;
+        --severity-high-bg: #3a2a1b;
+        --severity-critical: #ff453a;
+        --severity-critical-bg: #3a1b1b;
+    }
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.5;
+    padding: 2rem 1rem;
+}
+
+.container {
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+h1 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.badge {
+    display: inline-block;
+    background: var(--accent);
+    color: #fff;
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.1em 0.45em;
+    border-radius: 6px;
+    vertical-align: baseline;
+}
+
+.subtitle {
+    color: var(--hint-fg);
+    font-size: 0.95rem;
+}
+
+.subtitle a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.subtitle a:hover {
+    text-decoration: underline;
+}
+
+.input-row {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.vector-input {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    padding: 0.6rem 0.8rem;
+    border: 2px solid var(--input-border);
+    border-radius: 10px;
+    background: var(--input-bg);
+    color: var(--fg);
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.vector-input:focus {
+    border-color: var(--input-focus);
+}
+
+.vector-input::placeholder {
+    color: var(--hint-fg);
+    opacity: 0.7;
+}
+
+.share-btn {
+    font-size: 0.9rem;
+    padding: 0.6rem 1.2rem;
+    border: 2px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg-secondary);
+    color: var(--fg);
+    cursor: pointer;
+    transition: border-color 0.2s, background 0.2s;
+    white-space: nowrap;
+}
+
+.share-btn:hover:not(:disabled) {
+    background: var(--border);
+}
+
+.share-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.share-btn.copied {
+    border-color: var(--success-border);
+    color: var(--success-border);
+}
+
+.hint {
+    color: var(--hint-fg);
+    font-style: italic;
+    text-align: center;
+    padding: 2rem 0;
+}
+
+.error {
+    background: var(--error-bg);
+    border: 2px solid var(--error-border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    color: var(--error-fg);
+}
+
+.error strong {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.success {
+    background: var(--success-bg);
+    border: 2px solid var(--success-border);
+    border-radius: 10px;
+    padding: 1.25rem;
+}
+
+.score-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.version-badge {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.2em 0.6em;
+    border-radius: 6px;
+    background: var(--code-bg);
+    color: var(--fg);
+}
+
+.nomenclature-badge {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    padding: 0.2em 0.5em;
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    color: var(--hint-fg);
+}
+
+.score {
+    font-size: 1.75rem;
+    font-weight: 700;
+    font-family: var(--font-mono);
+}
+
+.severity-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.15em 0.6em;
+    border-radius: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.severity-none { color: var(--severity-none); }
+.severity-low { color: var(--severity-low); }
+.severity-medium { color: var(--severity-medium); }
+.severity-high { color: var(--severity-high); }
+.severity-critical { color: var(--severity-critical); }
+
+.severity-label.severity-none { background: var(--severity-none-bg); }
+.severity-label.severity-low { background: var(--severity-low-bg); }
+.severity-label.severity-medium { background: var(--severity-medium-bg); }
+.severity-label.severity-high { background: var(--severity-high-bg); }
+.severity-label.severity-critical { background: var(--severity-critical-bg); }
+
+.scores-detail {
+    display: flex;
+    gap: 1.25rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.score-item strong {
+    font-family: var(--font-mono);
+}
+
+.metric-group {
+    margin-top: 1rem;
+}
+
+.metric-group h3 {
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--hint-fg);
+    margin-bottom: 0.4rem;
+    padding-bottom: 0.25rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.metrics {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+}
+
+.metrics tr:not(:last-child) {
+    border-bottom: 1px solid rgba(128, 128, 128, 0.1);
+}
+
+.metrics td {
+    padding: 0.3rem 0.5rem;
+    vertical-align: top;
+}
+
+.metric-abbr {
+    width: 3.5rem;
+    white-space: nowrap;
+}
+
+.metric-abbr code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    font-weight: 600;
+    background: var(--code-bg);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+}
+
+.metric-name {
+    color: var(--hint-fg);
+}
+
+.metric-value code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: var(--code-bg);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+}
+
+footer {
+    text-align: center;
+    margin-top: 2.5rem;
+    color: var(--hint-fg);
+    font-size: 0.85rem;
+}
+
+footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary

* Add a browser-based CVSS vector string validator built with Leptos 0.8 (CSR) and Trunk
* Supports all four CVSS versions: v2.0, v3.0, v3.1, and v4.0 with auto-detection from the vector prefix
* Calculates and displays scores, severity ratings, and parsed metric tables grouped by category
* Includes URL sharing via `?vector=` query parameter and light/dark mode CSS
* Adds GitHub Pages deployment workflow

## Test plan

- [ ] Run `cd web && trunk serve` and test with sample vectors for each CVSS version
- [ ] Verify URL sharing: paste a vector, click Share, reload — input should repopulate
- [ ] Verify invalid input shows clear error messages
- [ ] Check light and dark mode rendering
- [ ] Run `cargo clippy -p cvss-web --target wasm32-unknown-unknown` and `cargo test -p cvss-rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)